### PR TITLE
refactor(i18n): align currency formatting with language settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Ghi Điểm Online 
+# Ghi Điểm Online
 
 [![Live Demo](https://img.shields.io/badge/demo-online-green.svg)](https://www.ghidiem.online/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5.5-blue.svg)](https://www.typescriptlang.org/)

--- a/src/hooks/useFormatCurrency.ts
+++ b/src/hooks/useFormatCurrency.ts
@@ -1,13 +1,14 @@
 import { useAppSelector } from '@/redux/hooks';
 import { RootState } from '@/redux/store';
-import { VND_SYMBOL } from '@/utils/constants';
+import { useTranslation } from 'react-i18next';
 import helpers from '@/utils/helpers';
 
 function useFormatCurrency() {
 	const settingValue = useAppSelector((state: RootState) => state.setting);
+	const { i18n, t } = useTranslation();
 
 	const formatCurrency = (value: number): string => {
-		return helpers.formatCurrency(value * settingValue.unit) + VND_SYMBOL;
+		return helpers.formatCurrencyWithSymbol(value, settingValue.unit, i18n.language, t);
 	};
 
 	return { formatCurrency };

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -2,12 +2,36 @@ import { DB_KEYS } from '@/utils/constants';
 import { ErrorType } from '../types';
 
 /**
- * Formats a number as Vietnamese currency
+ * Formats a number according to the specified locale
  * @param value - The number to format
+ * @param locale - The locale to use for formatting (e.g., 'vi-VN', 'en-US')
  * @returns Formatted string
  */
-export const formatCurrency = (value: number): string => {
-	return value.toLocaleString('vi-VN');
+export const formatCurrency = (value: number, locale: string = 'vi-VN'): string => {
+	return value.toLocaleString(locale);
+};
+
+/**
+ * Formats a currency value with symbol based on language and unit
+ * @param value - The base value to format
+ * @param unit - The unit multiplier (e.g., 1 or 1000)
+ * @param language - The language code ('vi' or 'en')
+ * @param t - Translation function from i18next
+ * @returns Formatted currency string with symbol
+ */
+export const formatCurrencyWithSymbol = (
+	value: number,
+	unit: number,
+	language: string,
+	t: (key: string) => string,
+): string => {
+	const calculatedValue = value * unit;
+	const locale = language === 'vi' ? 'vi-VN' : 'en-US';
+	const formattedNumber = formatCurrency(calculatedValue, locale);
+	const currencyKey = unit === 1 ? 'common.currency.1' : 'common.currency.1000';
+	const currencySymbol = t(currencyKey).replace(/^[\d,.]+/, '');
+
+	return formattedNumber + currencySymbol;
 };
 
 /**
@@ -118,6 +142,7 @@ export { translateError } from './errorTranslator';
 // Default export for backward compatibility
 const helpers = {
 	formatCurrency,
+	formatCurrencyWithSymbol,
 	stringToColor,
 	getShortName,
 	getFromLocalStorage,


### PR DESCRIPTION
Improved currency formatting to respect user's language preference by integrating i18n
 support throughout the currency formatting logic.

Changes:
- Refactored formatCurrency helper to accept locale parameter for flexible number formatting
- Added formatCurrencyWithSymbol helper that encapsulates complete currency formatting logic with i18n support
- Updated useFormatCurrency hook to integrate with i18next and delegate to new helper function
- Currency now displays "pt" (points) for English and "đ" for Vietnamese with appropriate locale formatting (en-US vs vi-VN)
- Improved code maintainability through better separation of concerns