### PR TITLE
fix(i18n): translate toast error messages instead of showing keys

### DIFF
--- a/src/pages/CreatingPage/hooks/useCreatingPage.ts
+++ b/src/pages/CreatingPage/hooks/useCreatingPage.ts
@@ -2,17 +2,18 @@ import { useAppDispatch } from '@/redux/hooks';
 import { updateMatches } from '@/redux/slices/matchSlice';
 import { ROUTES } from '@/routes/constants';
 import { matchService } from '@/services';
-import helpers from '@/utils/helpers';
-import { ErrorType } from '@/utils/types';
+import { translateError } from '@/utils/helpers';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { useForm } from 'react-hook-form';
 import { generatePath, useNavigate } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
 import { CreatingPageForm, schema } from '../utils';
 
 function useCreatingPage() {
 	const navigate = useNavigate();
 	const dispatch = useAppDispatch();
+	const { t } = useTranslation();
 
 	const { register, handleSubmit, formState } = useForm<CreatingPageForm>({
 		resolver: yupResolver(schema),
@@ -28,7 +29,7 @@ function useCreatingPage() {
 			const path = generatePath(ROUTES.MATCH, { id: newMatch.id });
 			navigate(path);
 		} catch (error) {
-			toast.error(helpers.getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 		}
 	};
 

--- a/src/pages/PlayingPage/hooks/usePlaying.ts
+++ b/src/pages/PlayingPage/hooks/usePlaying.ts
@@ -9,10 +9,11 @@ import {
 } from '@/redux/slices/matchSlice';
 import { RootState } from '@/redux/store';
 import { matchService } from '@/services';
-import { getErrorMessage, scrollToTop } from '@/utils/helpers';
-import { ErrorType, PlayerLeaderBoard } from '@/utils/types';
+import { translateError, scrollToTop } from '@/utils/helpers';
+import { PlayerLeaderBoard } from '@/utils/types';
 import { toast } from 'react-toastify';
 import { useMemo } from 'react';
+import { useTranslation } from 'react-i18next';
 
 /**
  * Custom hook for managing playing page state and operations
@@ -24,6 +25,7 @@ function usePlaying() {
 	const isFinished = match?.data.isFinished ?? false;
 	const isShowResult = match?.isShowResult ?? false;
 	const { updateQueryParams } = useAddQueryParams();
+	const { t } = useTranslation();
 
 	/**
 	 * Memoize players to ensure stable reference and prevent unnecessary recalculations
@@ -55,7 +57,7 @@ function usePlaying() {
 			const updatedMatch = matchService.get(matchId);
 			dispatch(updateMatchDetailData(updatedMatch));
 		} catch (error) {
-			toast.error(getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 		}
 	};
 
@@ -82,7 +84,7 @@ function usePlaying() {
 			dispatch(updateCurrentGame(gameNumber));
 			updateQueryParams({ gN: gameNumber.toString() });
 		} catch (error) {
-			toast.error(getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 		}
 	};
 
@@ -101,7 +103,7 @@ function usePlaying() {
 			dispatch(updateMatchDetail(payload));
 			updateQueryParams({ gN: nextGameNumber.toString() });
 		} catch (error) {
-			toast.error(getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 		} finally {
 			scrollToTop();
 		}
@@ -120,7 +122,7 @@ function usePlaying() {
 			const allMatches = matchService.getAll();
 			dispatch(updateMatches(allMatches));
 		} catch (error) {
-			toast.error(getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 		} finally {
 			scrollToTop();
 		}
@@ -143,7 +145,7 @@ function usePlaying() {
 
 			refreshMatchData();
 		} catch (error) {
-			toast.error(getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 		}
 	};
 
@@ -158,7 +160,7 @@ function usePlaying() {
 			matchService.updateScoreOfPlayer(matchId, playerId, gameNumber, score);
 			refreshMatchData();
 		} catch (error) {
-			toast.error(getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 		}
 	};
 
@@ -178,7 +180,7 @@ function usePlaying() {
 			matchService.updateScoreOfPlayer(matchId, playerId, gameNumber, -score);
 			refreshMatchData();
 		} catch (error) {
-			toast.error(getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 		}
 	};
 

--- a/src/pages/PlayingPage/hooks/usePlayingFetcher.ts
+++ b/src/pages/PlayingPage/hooks/usePlayingFetcher.ts
@@ -3,21 +3,22 @@ import { useAppDispatch } from '@/redux/hooks';
 import { updateIsShowResult, updateMatchDetail } from '@/redux/slices/matchSlice';
 import { ROUTES } from '@/routes/constants';
 import { matchService } from '@/services';
-import helpers from '@/utils/helpers';
-import { ErrorType } from '@/utils/types';
+import { translateError } from '@/utils/helpers';
 import { useCallback, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
 import { toast } from 'react-toastify';
+import { useTranslation } from 'react-i18next';
 
 function usePlayingFetcher() {
 	const dispatch = useAppDispatch();
 	const navigate = useNavigate();
 	const { id } = useParams();
 	const { params } = useAddQueryParams();
+	const { t } = useTranslation();
 
 	const fetchMatch = useCallback(() => {
 		try {
-			if (!id) throw new Error('Không tìm thấy trận đấu');
+			if (!id) throw new Error('errors.match.notFound');
 
 			const newMatch = matchService.get(+id);
 			const totalGameNumber = matchService.getCurrentGameNumber(+id);
@@ -31,12 +32,12 @@ function usePlayingFetcher() {
 			dispatch(updateMatchDetail(payload));
 			newMatch.isFinished && dispatch(updateIsShowResult(true));
 		} catch (error) {
-			toast.error(helpers.getErrorMessage(error as ErrorType));
+			toast.error(translateError(error, t));
 			navigate(ROUTES.HOME);
 		}
 
 		// eslint-disable-next-line react-hooks/exhaustive-deps
-	}, [id]);
+	}, [id, t]);
 
 	useEffect(() => {
 		fetchMatch();


### PR DESCRIPTION
Previously, error toast messages were displaying raw translation keys (e.g., "errors.game.scoreNotZero") instead of translated text because `getErrorMessage` was being used instead of `translateError`.

Changes:
- Added `useTranslation()` hook to usePlaying, usePlayingFetcher, and useCreatingPage
- Replaced all `getErrorMessage(error as ErrorType)` calls with `translateError(error, t)`
- Fixed 9 toast error messages across 3 files to properly display in user's selected language