### PR TITLE
feat(i18n): set Vietnamese as default language

### DIFF
--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -14,14 +14,11 @@ const resources = {
 	},
 };
 
-// Get language from settings in localStorage or browser
+// Get language from settings in localStorage
 const savedSettings = settingService.get();
-const browserLanguage = navigator.language.split('-')[0]; // Get 'en' from 'en-US', 'vi' from 'vi-VN'
-const supportedLanguages = ['en', 'vi'];
 
-// Priority: saved setting > browser language > fallback to Vietnamese
-const initialLanguage =
-	savedSettings.language || (supportedLanguages.includes(browserLanguage) ? browserLanguage : 'vi');
+// Priority: saved setting > default to Vietnamese
+const initialLanguage = savedSettings.language || 'vi';
 
 i18n
 	.use(LanguageDetector)


### PR DESCRIPTION
Remove browser language detection from initial language selection. App now defaults to Vietnamese unless user has saved a language preference.