### PR TITLE
feat(player): add individual gap setting and auto-fill checkbox

### DIFF
--- a/src/components/SettingDialog/SettingDialog.tsx
+++ b/src/components/SettingDialog/SettingDialog.tsx
@@ -1,12 +1,7 @@
 import { Dialog } from '@/components';
-import { Box, Slider, Stack, SxProps, Typography } from '@mui/material';
-import {
-	LANGUAGE_OPTIONS,
-	SLIDER_MARKS,
-	SLIDER_MAX_VALUE,
-	SLIDER_MIN_VALUE,
-	UNIT_OPTIONS,
-} from './constants';
+import { Box, Stack, SxProps, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
+import { LANGUAGE_OPTIONS, UNIT_OPTIONS } from './constants';
 import styles from './styles';
 import useSettingDialog from './useSettingDialog';
 import { useTranslation } from 'react-i18next';
@@ -89,21 +84,34 @@ type GapSelectionProps = {
 
 const GapSelection = ({ value, onChange }: GapSelectionProps) => {
 	const { t } = useTranslation();
+	const [displayValue, setDisplayValue] = useState<string>(value.toString());
+
+	const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const raw = e.target.value;
+		setDisplayValue(raw);
+		const num = +raw;
+		if (num >= 1) onChange(num);
+	};
+
+	const handleBlur = () => {
+		const num = +displayValue;
+		if (num < 1 || isNaN(num)) {
+			setDisplayValue(value.toString());
+		}
+	};
+
 	return (
 		<Stack>
 			<Typography sx={styles.title}>{t('components.settingDialog.gapValue')}</Typography>
-			<Box px="8px">
-				<Slider
-					min={SLIDER_MIN_VALUE}
-					max={SLIDER_MAX_VALUE}
-					marks={SLIDER_MARKS}
-					value={value}
-					onChange={(_e, gap) => onChange(+gap)}
-					sx={styles.gapSlider}
-					valueLabelDisplay="on"
-					aria-label="Always visible"
-				/>
-			</Box>
+			<TextField
+				type="number"
+				value={displayValue}
+				onChange={handleChange}
+				onBlur={handleBlur}
+				size="small"
+				inputProps={{ min: 1 }}
+				sx={{ maxWidth: '120px' }}
+			/>
 		</Stack>
 	);
 };

--- a/src/components/SettingDialog/constants.ts
+++ b/src/components/SettingDialog/constants.ts
@@ -1,27 +1,3 @@
-export const SLIDER_MIN_VALUE = 1;
-export const SLIDER_MAX_VALUE = 20;
-export const SLIDER_MARKS = [
-	{
-		value: 1,
-		label: '1',
-	},
-	{
-		value: 2,
-		label: '2',
-	},
-	{
-		value: 5,
-		label: '5',
-	},
-	{
-		value: 10,
-		label: '10',
-	},
-	{
-		value: 20,
-		label: '20',
-	},
-];
 export const UNIT_OPTIONS = [
 	{
 		value: 1,

--- a/src/components/SettingDialog/styles.ts
+++ b/src/components/SettingDialog/styles.ts
@@ -5,16 +5,6 @@ const styles = {
 		fontWeight: 'bold',
 		mb: '4px',
 	} as SxProps,
-	gapSlider: {
-		'& .MuiSlider-valueLabel': {
-			backgroundColor: '#1976d2de',
-			color: '#FFF',
-
-			'&:before': {
-				backgroundColor: '#1976d2de',
-			},
-		},
-	} as SxProps,
 	unitItem: (active: boolean) =>
 		({
 			cursor: 'pointer',

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -41,7 +41,9 @@
 			"continuePlay": "Continue Playing",
 			"paymentChart": "Payment Chart",
 			"scoreLabel": "Score: {{total}}",
-			"matchLabel": "Match: {{name}}"
+			"matchLabel": "Match: {{name}}",
+			"individualGap": "Individual increment/decrement",
+			"resetToGlobal": "Reset to default"
 		}
 	},
 	"components": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -41,7 +41,9 @@
 			"continuePlay": "Chơi tiếp",
 			"paymentChart": "Biểu đồ thanh toán",
 			"scoreLabel": "Điểm: {{total}}",
-			"matchLabel": "Trận: {{name}}"
+			"matchLabel": "Trận: {{name}}",
+			"individualGap": "Giá trị tăng/giảm riêng",
+			"resetToGlobal": "Đặt lại về mặc định"
 		}
 	},
 	"components": {

--- a/src/pages/PlayingPage/components/Player/Player.tsx
+++ b/src/pages/PlayingPage/components/Player/Player.tsx
@@ -5,8 +5,10 @@ import { Player as PlayerType } from '@/utils/types';
 import {
 	ArrowDownwardSharp as ArrowDownwardSharpIcon,
 	ArrowUpward as ArrowUpwardIcon,
+	Speed as SpeedIcon,
 } from '@mui/icons-material';
-import { Box, Stack, Typography } from '@mui/material';
+import { Box, Checkbox, FormControlLabel, Popover, Stack, TextField, Typography } from '@mui/material';
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { usePlaying } from '../../hooks';
 import styles from './styles';
@@ -19,19 +21,44 @@ type Props = {
 function Player({ player, onRename }: Props) {
 	const { t } = useTranslation();
 	const setting = useAppSelector((state: RootState) => state.setting);
-	const { match, onScorePlayerChange, onAutoFillScore } = usePlaying();
+	const { match, onScorePlayerChange, onToggleAutoFill, onUpdatePlayerGap } = usePlaying();
 	const currentGameNumber = match?.current ?? 1;
 	const total = player.scores.slice(0, currentGameNumber).reduce((acc, score) => acc + score, 0);
 	const increasingTrendValue = player.scores[currentGameNumber - 2] || 0;
 	const isFinished = match?.data.isFinished ?? false;
 	const currentValue = player.scores[currentGameNumber - 1] || 0;
+	const effectiveGap = player.gap ?? setting.gap;
+	const hasCustomGap = player.gap !== undefined;
+
+	const [gapAnchorEl, setGapAnchorEl] = useState<HTMLElement | null>(null);
+	const [gapDisplayValue, setGapDisplayValue] = useState<string>(effectiveGap.toString());
 
 	const handleScoreChange = (newValue: number) => {
 		onScorePlayerChange(player.id, currentGameNumber, newValue);
 	};
 
-	const handleAutoFill = () => {
-		onAutoFillScore(player.id, currentGameNumber);
+	const handleGapChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+		const raw = e.target.value;
+		setGapDisplayValue(raw);
+		const num = +raw;
+		if (num >= 1) onUpdatePlayerGap(player.id, num);
+	};
+
+	const handleGapBlur = () => {
+		const num = +gapDisplayValue;
+		if (num < 1 || isNaN(num)) {
+			setGapDisplayValue(effectiveGap.toString());
+		}
+	};
+
+	const handleOpenGapPopover = (e: React.MouseEvent<HTMLElement>) => {
+		setGapDisplayValue(effectiveGap.toString());
+		setGapAnchorEl(e.currentTarget);
+	};
+
+	const handleResetGap = () => {
+		onUpdatePlayerGap(player.id, undefined);
+		setGapAnchorEl(null);
 	};
 
 	return (
@@ -57,15 +84,71 @@ function Player({ player, onRename }: Props) {
 			</Stack>
 			<Stack gap="0.25rem">
 				<InputScore
-					disabled={isFinished}
+					disabled={isFinished || !!player.autoFill}
 					value={currentValue}
 					onChange={handleScoreChange}
-					gap={setting.gap}
+					gap={effectiveGap}
 				/>
 				{!isFinished && (
-					<Typography sx={styles.autoFill} onClick={handleAutoFill}>
-						{t('common.buttons.autoFill')}
-					</Typography>
+					<Stack direction="row" alignItems="center" justifyContent="center" gap="0.5rem">
+						<FormControlLabel
+							control={
+								<Checkbox
+									checked={!!player.autoFill}
+									onChange={() => onToggleAutoFill(player.id)}
+									size="small"
+									sx={{ p: '2px' }}
+								/>
+							}
+							label={
+								<Typography sx={{ fontSize: '14px' }}>
+									{t('common.buttons.autoFill')}
+								</Typography>
+							}
+							sx={{ m: 0 }}
+						/>
+						<Stack
+							direction="row"
+							alignItems="center"
+							onClick={handleOpenGapPopover}
+							sx={styles.gapBadge(hasCustomGap)}
+						>
+							<SpeedIcon sx={{ fontSize: '14px' }} />
+							<Typography sx={{ fontSize: '12px', fontWeight: 'bold' }}>
+								{effectiveGap}
+							</Typography>
+						</Stack>
+						<Popover
+							open={Boolean(gapAnchorEl)}
+							anchorEl={gapAnchorEl}
+							onClose={() => setGapAnchorEl(null)}
+							anchorOrigin={{ vertical: 'bottom', horizontal: 'center' }}
+							transformOrigin={{ vertical: 'top', horizontal: 'center' }}
+						>
+							<Stack sx={{ p: '12px 16px', width: '180px' }}>
+								<Typography sx={{ fontSize: '13px', fontWeight: 'bold', mb: '8px' }}>
+									{t('pages.playing.individualGap')}
+								</Typography>
+								<TextField
+									type="number"
+									value={gapDisplayValue}
+									onChange={handleGapChange}
+									onBlur={handleGapBlur}
+									size="small"
+									inputProps={{ min: 1 }}
+									autoFocus
+								/>
+								{hasCustomGap && (
+									<Typography
+										onClick={handleResetGap}
+										sx={styles.resetGap}
+									>
+										{t('pages.playing.resetToGlobal')}
+									</Typography>
+								)}
+							</Stack>
+						</Popover>
+					</Stack>
 				)}
 			</Stack>
 		</Stack>

--- a/src/pages/PlayingPage/components/Player/styles.ts
+++ b/src/pages/PlayingPage/components/Player/styles.ts
@@ -46,10 +46,23 @@ const styles = {
 		fontWeight: 'bold',
 		fontSize: '14px',
 	} as SxProps,
-	autoFill: {
-		fontSize: '14px',
-		textAlign: 'center',
+	gapBadge: (hasCustomGap: boolean) =>
+		({
+			cursor: 'pointer',
+			gap: '2px',
+			padding: '1px 6px',
+			borderRadius: '12px',
+			border: `1px solid ${hasCustomGap ? PRIMARY_COLOR : '#bbb'}`,
+			backgroundColor: hasCustomGap ? '#e3f2fd' : 'transparent',
+			color: hasCustomGap ? PRIMARY_COLOR : '#888',
+			userSelect: 'none',
+		}) as SxProps,
+	resetGap: {
+		fontSize: '12px',
+		color: '#D32F2F',
 		cursor: 'pointer',
+		textAlign: 'center',
+		mt: '4px',
 	} as SxProps,
 };
 

--- a/src/pages/PlayingPage/hooks/usePlaying.ts
+++ b/src/pages/PlayingPage/hooks/usePlaying.ts
@@ -165,19 +165,27 @@ function usePlaying() {
 	};
 
 	/**
-	 * Auto-fills a player's score to make the game sum to zero
-	 * @param playerId - Player ID to auto-fill
-	 * @param gameNumber - Game number (1-indexed)
+	 * Toggles autoFill for a player (only one at a time)
+	 * @param playerId - Player ID
 	 */
-	const onAutoFillScore = (playerId: number, gameNumber: number): void => {
+	const onToggleAutoFill = (playerId: number): void => {
 		try {
-			let score = 0;
-			match?.data.players.forEach((p) => {
-				if (p.id !== playerId) {
-					score = score + p.scores[gameNumber - 1];
-				}
-			});
-			matchService.updateScoreOfPlayer(matchId, playerId, gameNumber, -score);
+			const currentGameNumber = match?.current ?? 1;
+			const updatedMatch = matchService.togglePlayerAutoFill(matchId, playerId, currentGameNumber);
+			dispatch(updateMatchDetailData(updatedMatch));
+		} catch (error) {
+			toast.error(translateError(error, t));
+		}
+	};
+
+	/**
+	 * Updates a player's individual gap value
+	 * @param playerId - Player ID
+	 * @param gap - New gap value (undefined to reset to global)
+	 */
+	const onUpdatePlayerGap = (playerId: number, gap?: number): void => {
+		try {
+			matchService.updatePlayerGap(matchId, playerId, gap);
 			refreshMatchData();
 		} catch (error) {
 			toast.error(translateError(error, t));
@@ -200,7 +208,8 @@ function usePlaying() {
 		toggleShowResult,
 		onAdjustPlayer,
 		onScorePlayerChange,
-		onAutoFillScore,
+		onToggleAutoFill,
+		onUpdatePlayerGap,
 		moveToEnd,
 		onShowGameNumber,
 		onPlayContinue,

--- a/src/services/match/index.ts
+++ b/src/services/match/index.ts
@@ -158,6 +158,8 @@ const updateScoreOfPlayer = (
 		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
 	}
 
+	recalculateAutoFillPlayer(matchId, gameNumber);
+
 	return updatedPlayer;
 };
 
@@ -259,6 +261,99 @@ const endGame = (id: number): Match => {
 	return match;
 };
 
+/**
+ * Recalculates the autoFill player's score for a given game
+ * @param matchId - The match ID
+ * @param gameNumber - The game number (1-indexed)
+ */
+const recalculateAutoFillPlayer = (matchId: number, gameNumber: number): void => {
+	const match = matchDB.getMatch(matchId);
+	if (!match) return;
+
+	const autoFillPlayer = match.players.find((p) => p.autoFill);
+	if (!autoFillPlayer) return;
+
+	const otherPlayersSum = match.players
+		.filter((p) => p.id !== autoFillPlayer.id)
+		.reduce((sum, p) => sum + (p.scores[gameNumber - 1] || 0), 0);
+
+	autoFillPlayer.scores[gameNumber - 1] = -otherPlayersSum;
+	matchDB.updatePlayerOfMatch(matchId, autoFillPlayer);
+};
+
+/**
+ * Toggles autoFill for a player. Only one player can have autoFill at a time.
+ * @param matchId - The match ID
+ * @param playerId - The player ID
+ * @param gameNumber - The current game number (1-indexed)
+ * @returns The updated match
+ */
+const togglePlayerAutoFill = (matchId: number, playerId: number, gameNumber: number): Match => {
+	validateMatchId(matchId);
+	validatePlayerId(playerId);
+
+	const match = matchDB.getMatch(matchId);
+	if (!match) {
+		throw new Error(ERROR_MESSAGES.MATCH_NOT_FOUND);
+	}
+
+	const targetPlayer = match.players.find((p) => p.id === playerId);
+	if (!targetPlayer) {
+		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
+	}
+
+	const isEnabling = !targetPlayer.autoFill;
+
+	// Clear autoFill from all players first
+	match.players.forEach((p) => {
+		if (p.autoFill) {
+			p.autoFill = undefined;
+			matchDB.updatePlayerOfMatch(matchId, p);
+		}
+	});
+
+	if (isEnabling) {
+		targetPlayer.autoFill = true;
+
+		// Calculate score immediately
+		const otherPlayersSum = match.players
+			.filter((p) => p.id !== playerId)
+			.reduce((sum, p) => sum + (p.scores[gameNumber - 1] || 0), 0);
+		targetPlayer.scores[gameNumber - 1] = -otherPlayersSum;
+
+		matchDB.updatePlayerOfMatch(matchId, targetPlayer);
+	}
+
+	return get(matchId);
+};
+
+/**
+ * Updates a player's individual gap value
+ * @param matchId - The match ID
+ * @param playerId - The player ID
+ * @param gap - The new gap value (undefined to use global setting)
+ * @returns The updated player
+ * @throws Error if IDs are invalid or player not found
+ */
+const updatePlayerGap = (matchId: number, playerId: number, gap?: number): Player => {
+	validateMatchId(matchId);
+	validatePlayerId(playerId);
+
+	const currentPlayer = matchDB.getPlayerOfMatch(matchId, playerId);
+	if (!currentPlayer) {
+		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
+	}
+
+	currentPlayer.gap = gap;
+	const updatedPlayer = matchDB.updatePlayerOfMatch(matchId, currentPlayer);
+
+	if (!updatedPlayer) {
+		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
+	}
+
+	return updatedPlayer;
+};
+
 const matchService = {
 	create,
 	get,
@@ -268,6 +363,8 @@ const matchService = {
 	updatePlayerName,
 	updateScoreOfPlayer,
 	updatePositionOfPlayer,
+	updatePlayerGap,
+	togglePlayerAutoFill,
 	getCurrentGameNumber,
 	validateGameNumber: validateGameNumberScores,
 	nextGame,

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -2,6 +2,8 @@ export interface Player {
 	id: number;
 	name: string;
 	scores: number[];
+	gap?: number;
+	autoFill?: boolean;
 }
 
 export interface MatchWithoutPlayers {


### PR DESCRIPTION
⏺ Summary

  Add per-player settings for increment/decrement gap value and an auto-fill checkbox that automatically calculates a player's score as the negative
   sum of all other players.

  Changes

  - Add gap and autoFill optional fields to Player type
  - Add per-player gap popover with number input and reset-to-default option
  - Add auto-fill checkbox per player (mutually exclusive — only one at a time)
  - Auto-fill player score recalculates whenever other players' scores change
  - Replace global gap slider with number input field
  - Clean up unused slider constants and styles