### PR TITLE
feat(player): add avatar photo support and leaderboard highlight

### DIFF
--- a/src/components/PlayerModifierDialog/PlayerModifierDialog.tsx
+++ b/src/components/PlayerModifierDialog/PlayerModifierDialog.tsx
@@ -1,8 +1,17 @@
 import { Dialog } from '@/components';
 import helpers from '@/utils/helpers';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { Button, TextField, Typography } from '@mui/material';
-import React, { forwardRef, ReactNode, Ref, useImperativeHandle, useRef, useState } from 'react';
+import { CameraAlt as CameraAltIcon, Delete as DeleteIcon } from '@mui/icons-material';
+import { Avatar, Badge, Button, IconButton, Stack, TextField, Typography } from '@mui/material';
+import React, {
+	forwardRef,
+	ReactNode,
+	Ref,
+	useCallback,
+	useImperativeHandle,
+	useRef,
+	useState,
+} from 'react';
 import { useForm } from 'react-hook-form';
 import { useTranslation } from 'react-i18next';
 import { schema } from './schema';
@@ -12,18 +21,48 @@ import { Mode, PlayerForm } from './types';
 type Props = {
 	children: ReactNode;
 	onSubmit?: (name: string, id?: number) => void;
+	onAvatarChange?: (playerId: number, avatar?: string) => void;
 };
 
 export type PlayerModifierDialogRefType = {
 	editPlayerName: (player: PlayerForm) => void;
 };
 
+const MAX_AVATAR_SIZE = 200;
+
+const resizeImage = (file: File): Promise<string> => {
+	return new Promise((resolve) => {
+		const reader = new FileReader();
+		reader.onload = (e) => {
+			const img = new Image();
+			img.onload = () => {
+				const canvas = document.createElement('canvas');
+				const size = Math.min(img.width, img.height);
+				const sx = (img.width - size) / 2;
+				const sy = (img.height - size) / 2;
+				canvas.width = MAX_AVATAR_SIZE;
+				canvas.height = MAX_AVATAR_SIZE;
+				const ctx = canvas.getContext('2d')!;
+				ctx.drawImage(img, sx, sy, size, size, 0, 0, MAX_AVATAR_SIZE, MAX_AVATAR_SIZE);
+				resolve(canvas.toDataURL('image/jpeg', 0.7));
+			};
+			img.src = e.target?.result as string;
+		};
+		reader.readAsDataURL(file);
+	});
+};
+
 const PlayerModifierDialog = forwardRef(
-	({ children, onSubmit = () => {} }: Props, ref: Ref<PlayerModifierDialogRefType>) => {
+	(
+		{ children, onSubmit = () => {}, onAvatarChange }: Props,
+		ref: Ref<PlayerModifierDialogRefType>,
+	) => {
 		const { t } = useTranslation();
 		const [mode, setMode] = useState<Mode>(Mode.Create);
 		const [isOpen, setIsOpen] = useState(false);
+		const [avatarPreview, setAvatarPreview] = useState<string | undefined>();
 		const editedPlayerRef = useRef<PlayerForm | null>(null);
+		const fileInputRef = useRef<HTMLInputElement>(null);
 
 		const {
 			register,
@@ -42,6 +81,7 @@ const PlayerModifierDialog = forwardRef(
 			setIsOpen(false);
 			reset();
 			setMode(Mode.Create);
+			setAvatarPreview(undefined);
 			editedPlayerRef.current = null;
 			helpers.scrollToTop();
 		};
@@ -65,11 +105,36 @@ const PlayerModifierDialog = forwardRef(
 			handleClose();
 		};
 
+		const handleAvatarClick = () => {
+			fileInputRef.current?.click();
+		};
+
+		const handleFileChange = useCallback(
+			async (e: React.ChangeEvent<HTMLInputElement>) => {
+				const file = e.target.files?.[0];
+				if (!file || !editedPlayerRef.current?.id) return;
+
+				const base64 = await resizeImage(file);
+				setAvatarPreview(base64);
+				onAvatarChange?.(editedPlayerRef.current.id, base64);
+
+				if (fileInputRef.current) fileInputRef.current.value = '';
+			},
+			[onAvatarChange],
+		);
+
+		const handleRemoveAvatar = () => {
+			if (!editedPlayerRef.current?.id) return;
+			setAvatarPreview(undefined);
+			onAvatarChange?.(editedPlayerRef.current.id, undefined);
+		};
+
 		useImperativeHandle(ref, () => ({
 			editPlayerName: (player: PlayerForm) => {
 				setIsOpen(true);
 				setMode(Mode.Edit);
 				setValue('name', player?.name ?? '');
+				setAvatarPreview(player?.avatar);
 				editedPlayerRef.current = player;
 			},
 		}));
@@ -87,6 +152,48 @@ const PlayerModifierDialog = forwardRef(
 								: t('components.playerModifier.titleEdit')}
 						</Dialog.DialogTitle>
 						<Dialog.DialogContent sx={styles.dialogContent} dividers>
+							{mode === Mode.Edit && (
+								<Stack alignItems="center" mb="1rem">
+									<Badge
+										overlap="circular"
+										anchorOrigin={{ vertical: 'bottom', horizontal: 'right' }}
+										badgeContent={
+											avatarPreview ? (
+												<IconButton
+													size="small"
+													onClick={handleRemoveAvatar}
+													sx={styles.avatarBadgeBtn}
+												>
+													<DeleteIcon sx={{ fontSize: 14 }} />
+												</IconButton>
+											) : (
+												<IconButton
+													size="small"
+													onClick={handleAvatarClick}
+													sx={styles.avatarBadgeBtn}
+												>
+													<CameraAltIcon sx={{ fontSize: 14 }} />
+												</IconButton>
+											)
+										}
+									>
+										<Avatar
+											src={avatarPreview}
+											sx={styles.avatarLarge(editedPlayerRef.current?.name)}
+											onClick={handleAvatarClick}
+										>
+											{helpers.getShortName(editedPlayerRef.current?.name ?? '')}
+										</Avatar>
+									</Badge>
+									<input
+										ref={fileInputRef}
+										type="file"
+										accept="image/*"
+										hidden
+										onChange={handleFileChange}
+									/>
+								</Stack>
+							)}
 							<TextField
 								{...register('name')}
 								error={!!errors.name}

--- a/src/components/PlayerModifierDialog/styles.ts
+++ b/src/components/PlayerModifierDialog/styles.ts
@@ -1,16 +1,33 @@
+import { PRIMARY_COLOR } from '@/utils/constants';
+import helpers from '@/utils/helpers';
 import { SxProps } from '@mui/material';
 
-const styles: { [key: string]: SxProps } = {
+const styles = {
 	dialogContent: {
 		padding: '1.5rem 1rem 1rem',
-	},
-	input: { width: '100%' },
-	actions: { mt: 1.5, flexDirection: 'row', gap: 1, justifyContent: 'flex-end' },
+	} as SxProps,
+	input: { width: '100%' } as SxProps,
+	actions: { mt: 1.5, flexDirection: 'row', gap: 1, justifyContent: 'flex-end' } as SxProps,
 	tip: {
 		mt: 1,
 		fontSize: '0.8rem',
 		fontStyle: 'italic',
-	},
+	} as SxProps,
+	avatarLarge: (name?: string) =>
+		({
+			width: 72,
+			height: 72,
+			cursor: 'pointer',
+			bgcolor: helpers.stringToColor(name ?? ''),
+			fontSize: '1.5rem',
+		}) as SxProps,
+	avatarBadgeBtn: {
+		backgroundColor: PRIMARY_COLOR,
+		color: '#FFF',
+		width: 24,
+		height: 24,
+		'&:hover': { backgroundColor: '#1565c0' },
+	} as SxProps,
 };
 
 export default styles;

--- a/src/pages/PlayingPage/components/DragDropPlayer/styles.ts
+++ b/src/pages/PlayingPage/components/DragDropPlayer/styles.ts
@@ -1,5 +1,5 @@
 const styles: { [key: string]: React.CSSProperties } = {
-	provider: { rowGap: 20, display: 'flex', flexDirection: 'column' },
+	provider: { rowGap: 10, display: 'flex', flexDirection: 'column' },
 	dragItem: {
 		display: 'flex',
 	},

--- a/src/pages/PlayingPage/components/Hero/Hero.tsx
+++ b/src/pages/PlayingPage/components/Hero/Hero.tsx
@@ -13,7 +13,7 @@ import styles from './styles';
 import DragDropPlayer from '../DragDropPlayer';
 
 function Hero() {
-	const { isEmptyPlayer, isFinished, match, onAdjustPlayer } = usePlaying();
+	const { isEmptyPlayer, isFinished, match, onAdjustPlayer, onUpdatePlayerAvatar } = usePlaying();
 	const playerModifierDialogRef = useRef<PlayerModifierDialogRefType>(null);
 
 	const onRenamePlayer = (player: PlayerType) => {
@@ -33,7 +33,7 @@ function Hero() {
 						{(player) => <Player key={player.id} player={player} onRename={onRenamePlayer} />}
 					</DragDropPlayer>
 					{isAllowedActionForPlayer && (
-						<PlayerModifierDialog ref={playerModifierDialogRef} onSubmit={onAdjustPlayer}>
+						<PlayerModifierDialog ref={playerModifierDialogRef} onSubmit={onAdjustPlayer} onAvatarChange={onUpdatePlayerAvatar}>
 							<Button variant="contained" size="small" startIcon={<AddIcon />} />
 						</PlayerModifierDialog>
 					)}

--- a/src/pages/PlayingPage/components/Hero/Hero.tsx
+++ b/src/pages/PlayingPage/components/Hero/Hero.tsx
@@ -33,7 +33,11 @@ function Hero() {
 						{(player) => <Player key={player.id} player={player} onRename={onRenamePlayer} />}
 					</DragDropPlayer>
 					{isAllowedActionForPlayer && (
-						<PlayerModifierDialog ref={playerModifierDialogRef} onSubmit={onAdjustPlayer} onAvatarChange={onUpdatePlayerAvatar}>
+						<PlayerModifierDialog
+							ref={playerModifierDialogRef}
+							onSubmit={onAdjustPlayer}
+							onAvatarChange={onUpdatePlayerAvatar}
+						>
 							<Button variant="contained" size="small" startIcon={<AddIcon />} />
 						</PlayerModifierDialog>
 					)}

--- a/src/pages/PlayingPage/components/LeaderBoard/LeaderBoard.tsx
+++ b/src/pages/PlayingPage/components/LeaderBoard/LeaderBoard.tsx
@@ -83,7 +83,9 @@ const Player = ({ top, name, score, avatar }: PlayerProps) => {
 		<Box sx={styles.player}>
 			<Box sx={styles.playerLeftInfo}>
 				<Typography sx={styles.top}>{top}</Typography>
-				<Avatar src={avatar} sx={styles.playerAvatar(name)}>{helpers.getShortName(name)}</Avatar>
+				<Avatar src={avatar} sx={styles.playerAvatar(name)}>
+					{helpers.getShortName(name)}
+				</Avatar>
 				<Typography sx={styles.playerName}>{name}</Typography>
 			</Box>
 			<Typography sx={styles.score}>{formatCurrency(score)}</Typography>

--- a/src/pages/PlayingPage/components/LeaderBoard/LeaderBoard.tsx
+++ b/src/pages/PlayingPage/components/LeaderBoard/LeaderBoard.tsx
@@ -38,7 +38,18 @@ function LeaderBoard() {
 							<ArrowBackIcon />
 						</IconButton>
 						{t('pages.playing.leaderboard')}
-						<Button variant="outlined" onClick={handleShowTransactions}>
+						<Button
+							variant="outlined"
+							onClick={handleShowTransactions}
+							sx={{
+								animation: 'pulse 2s infinite',
+								'@keyframes pulse': {
+									'0%': { boxShadow: '0 0 0 0 rgba(25, 118, 210, 0.4)' },
+									'70%': { boxShadow: '0 0 0 10px rgba(25, 118, 210, 0)' },
+									'100%': { boxShadow: '0 0 0 0 rgba(25, 118, 210, 0)' },
+								},
+							}}
+						>
 							<PaidIcon />
 						</Button>
 					</Stack>
@@ -62,16 +73,17 @@ type PlayerProps = {
 	top: number;
 	name: string;
 	score: number;
+	avatar?: string;
 };
 
-const Player = ({ top, name, score }: PlayerProps) => {
+const Player = ({ top, name, score, avatar }: PlayerProps) => {
 	const { formatCurrency } = useFormatCurrency();
 
 	return (
 		<Box sx={styles.player}>
 			<Box sx={styles.playerLeftInfo}>
 				<Typography sx={styles.top}>{top}</Typography>
-				<Avatar sx={styles.playerAvatar(name)}>{helpers.getShortName(name)}</Avatar>
+				<Avatar src={avatar} sx={styles.playerAvatar(name)}>{helpers.getShortName(name)}</Avatar>
 				<Typography sx={styles.playerName}>{name}</Typography>
 			</Box>
 			<Typography sx={styles.score}>{formatCurrency(score)}</Typography>

--- a/src/pages/PlayingPage/components/Player/Player.tsx
+++ b/src/pages/PlayingPage/components/Player/Player.tsx
@@ -76,16 +76,17 @@ function Player({ player, onRename }: Props) {
 	return (
 		<Stack sx={styles.wrapper}>
 			<Stack sx={styles.row}>
-				<Stack direction="row" alignItems="center" gap="6px" onClick={() => onRename(player)} sx={{ cursor: 'pointer' }}>
-					<Avatar
-						src={player.avatar}
-						sx={styles.playerAvatar(player.name)}
-					>
+				<Stack
+					direction="row"
+					alignItems="center"
+					gap="6px"
+					onClick={() => onRename(player)}
+					sx={{ cursor: 'pointer' }}
+				>
+					<Avatar src={player.avatar} sx={styles.playerAvatar(player.name)}>
 						{helpers.getShortName(player.name)}
 					</Avatar>
-					<Typography sx={styles.title}>
-						{player.name}
-					</Typography>
+					<Typography sx={styles.title}>{player.name}</Typography>
 				</Stack>
 				<InputScore
 					disabled={isFinished || !!player.autoFill}
@@ -103,9 +104,7 @@ function Player({ player, onRename }: Props) {
 						<Stack sx={styles.trendWrapper(increasingTrendValue)}>
 							<Box>{`(`}</Box>
 							{increasingTrendValue >= 0 && <ArrowUpwardIcon sx={styles.trendIndicator} />}
-							{increasingTrendValue < 0 && (
-								<ArrowDownwardSharpIcon sx={styles.trendIndicator} />
-							)}
+							{increasingTrendValue < 0 && <ArrowDownwardSharpIcon sx={styles.trendIndicator} />}
 							<Typography sx={styles.trendMetric}>{increasingTrendValue}</Typography>
 							<Box>{`)`}</Box>
 						</Stack>
@@ -134,9 +133,7 @@ function Player({ player, onRename }: Props) {
 							sx={styles.gapBadge(hasCustomGap)}
 						>
 							<SpeedIcon sx={{ fontSize: '14px' }} />
-							<Typography sx={{ fontSize: '12px', fontWeight: 'bold' }}>
-								{effectiveGap}
-							</Typography>
+							<Typography sx={{ fontSize: '12px', fontWeight: 'bold' }}>{effectiveGap}</Typography>
 						</Stack>
 						<Popover
 							open={Boolean(gapAnchorEl)}

--- a/src/pages/PlayingPage/components/Player/Player.tsx
+++ b/src/pages/PlayingPage/components/Player/Player.tsx
@@ -1,6 +1,7 @@
 import { InputScore } from '@/components';
 import { useAppSelector } from '@/redux/hooks';
 import { RootState } from '@/redux/store';
+import helpers from '@/utils/helpers';
 import { Player as PlayerType } from '@/utils/types';
 import {
 	ArrowDownwardSharp as ArrowDownwardSharpIcon,
@@ -8,6 +9,7 @@ import {
 	Speed as SpeedIcon,
 } from '@mui/icons-material';
 import {
+	Avatar,
 	Box,
 	Checkbox,
 	FormControlLabel,
@@ -73,10 +75,26 @@ function Player({ player, onRename }: Props) {
 
 	return (
 		<Stack sx={styles.wrapper}>
-			<Stack sx={styles.titleWrapper}>
-				<Typography sx={styles.title} onClick={() => onRename(player)}>
-					{player.name}
-				</Typography>
+			<Stack sx={styles.row}>
+				<Stack direction="row" alignItems="center" gap="6px" onClick={() => onRename(player)} sx={{ cursor: 'pointer' }}>
+					<Avatar
+						src={player.avatar}
+						sx={styles.playerAvatar(player.name)}
+					>
+						{helpers.getShortName(player.name)}
+					</Avatar>
+					<Typography sx={styles.title}>
+						{player.name}
+					</Typography>
+				</Stack>
+				<InputScore
+					disabled={isFinished || !!player.autoFill}
+					value={currentValue}
+					onChange={handleScoreChange}
+					gap={effectiveGap}
+				/>
+			</Stack>
+			<Stack sx={styles.row}>
 				<Stack sx={styles.scoreWrapper}>
 					<Typography sx={styles.score(total)}>
 						{t('pages.playing.scoreLabel', { total })}
@@ -85,22 +103,16 @@ function Player({ player, onRename }: Props) {
 						<Stack sx={styles.trendWrapper(increasingTrendValue)}>
 							<Box>{`(`}</Box>
 							{increasingTrendValue >= 0 && <ArrowUpwardIcon sx={styles.trendIndicator} />}
-							{increasingTrendValue < 0 && <ArrowDownwardSharpIcon sx={styles.trendIndicator} />}
+							{increasingTrendValue < 0 && (
+								<ArrowDownwardSharpIcon sx={styles.trendIndicator} />
+							)}
 							<Typography sx={styles.trendMetric}>{increasingTrendValue}</Typography>
 							<Box>{`)`}</Box>
 						</Stack>
 					)}
 				</Stack>
-			</Stack>
-			<Stack gap="0.25rem">
-				<InputScore
-					disabled={isFinished || !!player.autoFill}
-					value={currentValue}
-					onChange={handleScoreChange}
-					gap={effectiveGap}
-				/>
 				{!isFinished && (
-					<Stack direction="row" alignItems="center" justifyContent="center" gap="0.5rem">
+					<Stack direction="row" alignItems="center" gap="0.5rem">
 						<FormControlLabel
 							control={
 								<Checkbox
@@ -111,7 +123,7 @@ function Player({ player, onRename }: Props) {
 								/>
 							}
 							label={
-								<Typography sx={{ fontSize: '14px' }}>{t('common.buttons.autoFill')}</Typography>
+								<Typography sx={{ fontSize: '13px' }}>{t('common.buttons.autoFill')}</Typography>
 							}
 							sx={{ m: 0 }}
 						/>
@@ -122,7 +134,9 @@ function Player({ player, onRename }: Props) {
 							sx={styles.gapBadge(hasCustomGap)}
 						>
 							<SpeedIcon sx={{ fontSize: '14px' }} />
-							<Typography sx={{ fontSize: '12px', fontWeight: 'bold' }}>{effectiveGap}</Typography>
+							<Typography sx={{ fontSize: '12px', fontWeight: 'bold' }}>
+								{effectiveGap}
+							</Typography>
 						</Stack>
 						<Popover
 							open={Boolean(gapAnchorEl)}

--- a/src/pages/PlayingPage/components/Player/styles.ts
+++ b/src/pages/PlayingPage/components/Player/styles.ts
@@ -1,24 +1,32 @@
 import { PRIMARY_COLOR } from '@/utils/constants';
+import helpers from '@/utils/helpers';
 import { SxProps } from '@mui/material';
 
 const styles = {
 	wrapper: {
-		flexDirection: 'row',
-		justifyContent: 'space-between',
-		padding: '12px',
-		border: `1.5px solid #1976d2`,
+		padding: '8px 12px',
+		gap: '4px',
+		border: `1px solid #1976d2`,
 		borderRadius: '0.5rem',
 		backgroundColor: '#FFF',
 		flex: 1,
 	} as SxProps,
-	titleWrapper: {
-		gap: '0.5rem',
+	row: {
+		flexDirection: 'row',
+		justifyContent: 'space-between',
+		alignItems: 'center',
 	} as SxProps,
+	playerAvatar: (name: string) =>
+		({
+			width: 28,
+			height: 28,
+			fontSize: '0.75rem',
+			bgcolor: helpers.stringToColor(name),
+		}) as SxProps,
 	title: {
 		whiteSpace: 'nowrap',
 		fontWeight: 'bold',
 		fontSize: '15px',
-		cursor: 'pointer',
 		userSelect: 'none',
 	} as SxProps,
 	scoreWrapper: {

--- a/src/pages/PlayingPage/components/TopOne/TopOne.tsx
+++ b/src/pages/PlayingPage/components/TopOne/TopOne.tsx
@@ -19,7 +19,9 @@ function TopOne({ name, score, avatar }: Props) {
 			<Box sx={styles.wrapper}>
 				<Box sx={styles.avatarWrapper}>
 					<img src={Crown} alt="Crown" style={styles.iconCrown as CSSProperties} />
-					<Avatar src={avatar} sx={styles.avatar(name)}>{helpers.getShortName(name)}</Avatar>
+					<Avatar src={avatar} sx={styles.avatar(name)}>
+						{helpers.getShortName(name)}
+					</Avatar>
 					<div style={styles.topNumber as CSSProperties}>1</div>
 				</Box>
 			</Box>

--- a/src/pages/PlayingPage/components/TopOne/TopOne.tsx
+++ b/src/pages/PlayingPage/components/TopOne/TopOne.tsx
@@ -8,9 +8,10 @@ import styles from './styles';
 type Props = {
 	name: string;
 	score: number;
+	avatar?: string;
 };
 
-function TopOne({ name, score }: Props) {
+function TopOne({ name, score, avatar }: Props) {
 	const { formatCurrency } = useFormatCurrency();
 
 	return (
@@ -18,7 +19,7 @@ function TopOne({ name, score }: Props) {
 			<Box sx={styles.wrapper}>
 				<Box sx={styles.avatarWrapper}>
 					<img src={Crown} alt="Crown" style={styles.iconCrown as CSSProperties} />
-					<Avatar sx={styles.avatar(name)}>{helpers.getShortName(name)}</Avatar>
+					<Avatar src={avatar} sx={styles.avatar(name)}>{helpers.getShortName(name)}</Avatar>
 					<div style={styles.topNumber as CSSProperties}>1</div>
 				</Box>
 			</Box>

--- a/src/pages/PlayingPage/hooks/usePlaying.ts
+++ b/src/pages/PlayingPage/hooks/usePlaying.ts
@@ -44,6 +44,7 @@ function usePlaying() {
 					id: p.id,
 					name: p.name,
 					score: p.scores.reduce((total, current) => total + current, 0),
+					avatar: p.avatar,
 				}))
 				.sort((a, b) => b.score - a.score),
 		[players],
@@ -193,6 +194,20 @@ function usePlaying() {
 	};
 
 	/**
+	 * Updates a player's avatar
+	 * @param playerId - Player ID
+	 * @param avatar - Base64 image string (undefined to remove)
+	 */
+	const onUpdatePlayerAvatar = (playerId: number, avatar?: string): void => {
+		try {
+			matchService.updatePlayerAvatar(matchId, playerId, avatar);
+			refreshMatchData();
+		} catch (error) {
+			toast.error(translateError(error, t));
+		}
+	};
+
+	/**
 	 * Toggles the visibility of the result modal
 	 */
 	const toggleShowResult = (): void => {
@@ -210,6 +225,7 @@ function usePlaying() {
 		onScorePlayerChange,
 		onToggleAutoFill,
 		onUpdatePlayerGap,
+		onUpdatePlayerAvatar,
 		moveToEnd,
 		onShowGameNumber,
 		onPlayContinue,

--- a/src/services/match/index.ts
+++ b/src/services/match/index.ts
@@ -354,6 +354,32 @@ const updatePlayerGap = (matchId: number, playerId: number, gap?: number): Playe
 	return updatedPlayer;
 };
 
+/**
+ * Updates a player's avatar
+ * @param matchId - The match ID
+ * @param playerId - The player ID
+ * @param avatar - Base64 image string (undefined to remove)
+ * @returns The updated player
+ */
+const updatePlayerAvatar = (matchId: number, playerId: number, avatar?: string): Player => {
+	validateMatchId(matchId);
+	validatePlayerId(playerId);
+
+	const currentPlayer = matchDB.getPlayerOfMatch(matchId, playerId);
+	if (!currentPlayer) {
+		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
+	}
+
+	currentPlayer.avatar = avatar;
+	const updatedPlayer = matchDB.updatePlayerOfMatch(matchId, currentPlayer);
+
+	if (!updatedPlayer) {
+		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
+	}
+
+	return updatedPlayer;
+};
+
 const matchService = {
 	create,
 	get,
@@ -364,6 +390,7 @@ const matchService = {
 	updateScoreOfPlayer,
 	updatePositionOfPlayer,
 	updatePlayerGap,
+	updatePlayerAvatar,
 	togglePlayerAutoFill,
 	getCurrentGameNumber,
 	validateGameNumber: validateGameNumberScores,

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -4,6 +4,7 @@ export interface Player {
 	scores: number[];
 	gap?: number;
 	autoFill?: boolean;
+	avatar?: string;
 }
 
 export interface MatchWithoutPlayers {
@@ -36,4 +37,5 @@ export interface PlayerLeaderBoard {
 	id: number;
 	name: string;
 	score: number;
+	avatar?: string;
 }


### PR DESCRIPTION
Allow players to upload a photo avatar via the edit player dialog. Avatars display next to player names, in the leaderboard, and on the top one podium. Add pulse animation to payment chart button.