### PR TITLE
feat(transactions): add avatar photos to payment chart nodes

### DIFF
--- a/src/pages/PlayingPage/components/Transactions/Transactions.tsx
+++ b/src/pages/PlayingPage/components/Transactions/Transactions.tsx
@@ -1,11 +1,51 @@
 import { Dialog } from '@/components';
+import helpers from '@/utils/helpers';
 import { ArrowBack as ArrowBackIcon } from '@mui/icons-material';
+import { Avatar } from '@mui/material';
 import { IconButton, Stack } from '@mui/material';
-import { ReactFlow, Node as ReactFlowNode } from '@xyflow/react';
+import { Handle, Position, ReactFlow, Node as ReactFlowNode } from '@xyflow/react';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useTransactions } from '../../hooks';
 import styles from './styles';
 import classes from './Transactions.module.scss';
+
+type AvatarNodeProps = {
+	data: { label: string; avatar?: string };
+	type?: string;
+};
+
+function AvatarNode({ data, type }: AvatarNodeProps) {
+	return (
+		<>
+			{type !== 'output' && <Handle type="source" position={Position.Right} />}
+			{type !== 'input' && <Handle type="target" position={Position.Left} />}
+			<Stack direction="row" alignItems="center" gap="4px" sx={{ px: '6px' }}>
+				<Avatar
+					src={data.avatar}
+					sx={{
+						width: 22,
+						height: 22,
+						fontSize: '10px',
+						bgcolor: 'rgba(255,255,255,0.3)',
+					}}
+				>
+					{helpers.getShortName(data.label)}
+				</Avatar>
+				<span
+					style={{
+						overflow: 'hidden',
+						textOverflow: 'ellipsis',
+						whiteSpace: 'nowrap',
+						fontSize: '12px',
+					}}
+				>
+					{data.label}
+				</span>
+			</Stack>
+		</>
+	);
+}
 
 type Props = {
 	isOpen: boolean;
@@ -15,6 +55,16 @@ type Props = {
 function Transactions({ isOpen, onClose }: Props) {
 	const { t } = useTranslation();
 	const { edges, nodes } = useTransactions();
+
+	const nodeTypes = useMemo(
+		() => ({
+			input: (props: AvatarNodeProps) => <AvatarNode {...props} type="input" />,
+			output: (props: AvatarNodeProps) => <AvatarNode {...props} type="output" />,
+			default: AvatarNode,
+		}),
+		[],
+	);
+
 	return (
 		<Dialog isOpen={isOpen} fullScreen>
 			<Dialog.DialogTitle>
@@ -30,6 +80,7 @@ function Transactions({ isOpen, onClose }: Props) {
 					className={classes.reactFlow}
 					nodes={nodes as ReactFlowNode[]}
 					edges={edges}
+					nodeTypes={nodeTypes}
 					fitView
 				/>
 			</Dialog.DialogContent>

--- a/src/pages/PlayingPage/hooks/useTransactions.ts
+++ b/src/pages/PlayingPage/hooks/useTransactions.ts
@@ -120,7 +120,7 @@ function useTransactions() {
 				sourcePosition: 'right',
 				targetPosition: 'left',
 				style: {
-					width: 120,
+					width: 140,
 					height: nodeHeight,
 					background: helpers.stringToColor(player.name),
 					color: 'white',
@@ -131,6 +131,7 @@ function useTransactions() {
 				},
 				data: {
 					label: player.name,
+					avatar: player.avatar,
 				},
 			};
 		});


### PR DESCRIPTION
  ## Summary
  Add player avatar photos to the transaction/payment chart nodes in the ReactFlow diagram.

  ## Changes
  - Create custom `AvatarNode` component with avatar photo and player name
  - Register custom node types (input, output, default) in ReactFlow
  - Pass avatar data through node data in `useTransactions` hook
  - Increase node width from 120 to 140 to accommodate avatars