### PR TITLE
  style(player): increase avatar size for better mobile visibility

### DIFF
--- a/src/pages/PlayingPage/components/Player/styles.ts
+++ b/src/pages/PlayingPage/components/Player/styles.ts
@@ -18,9 +18,9 @@ const styles = {
 	} as SxProps,
 	playerAvatar: (name: string) =>
 		({
-			width: 28,
-			height: 28,
-			fontSize: '0.75rem',
+			width: 36,
+			height: 36,
+			fontSize: '0.85rem',
 			bgcolor: helpers.stringToColor(name),
 		}) as SxProps,
 	title: {


### PR DESCRIPTION
  ## Summary
  Increases player avatar size from 28px to 36px for better visibility on mobile devices.

  ## Changes
  - Increase player avatar width/height from 28px to 36px
  - Increase avatar font size from 0.75rem to 0.85rem