### PR TITLE
chore(i18n): temporarily disable English and force Vietnamese

### DIFF
--- a/src/components/SettingDialog/SettingDialog.tsx
+++ b/src/components/SettingDialog/SettingDialog.tsx
@@ -27,7 +27,8 @@ function SettingDialog({ isOpen, onClose }: Props) {
 				<Stack gap="1rem">
 					<UnitSelection value={unit} onChange={onUnitChange} />
 					<GapSelection value={gap} onChange={onGapChange} />
-					<LanguageSelection value={language} onChange={onLanguageChange} />
+					{/* TODO: temporarily disabled English, re-enable later */}
+					{/* <LanguageSelection value={language} onChange={onLanguageChange} /> */}
 					<p style={{ fontSize: '14px', color: '#555' }}>
 						{t('components.settingDialog.copyright')}
 					</p>

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -18,7 +18,8 @@ const resources = {
 const savedSettings = settingService.get();
 
 // Priority: saved setting > default to Vietnamese
-const initialLanguage = savedSettings.language || 'vi';
+// TODO: temporarily force Vietnamese, re-enable English later
+const initialLanguage = 'vi';
 
 i18n
 	.use(LanguageDetector)

--- a/src/pages/PlayingPage/components/LeaderBoard/styles.ts
+++ b/src/pages/PlayingPage/components/LeaderBoard/styles.ts
@@ -45,7 +45,7 @@ const styles = {
 	playerAvatar: (name: string) =>
 		({
 			bgcolor: helpers.stringToColor(name),
-			border: `1px dashed ${PRIMARY_COLOR}`,
+			border: `1px solid ${PRIMARY_COLOR}`,
 		}) as SxProps,
 	playerName: {
 		fontWeight: '500',


### PR DESCRIPTION
  ## Summary
  Temporarily disable English language support and force Vietnamese as the only language option, plus a minor UI fix on the leaderboard.

  ## Changes
  - Force `initialLanguage` to `'vi'` in i18n config, bypassing saved user preference
  - Comment out `LanguageSelection` component in the settings dialog
  - Change leaderboard player avatar border style from `dashed` to `solid`