### PR TITLE
  style(player): improve trend indicators and highlight autofill players

### DIFF
--- a/src/pages/PlayingPage/components/Player/Player.tsx
+++ b/src/pages/PlayingPage/components/Player/Player.tsx
@@ -4,10 +4,11 @@ import { RootState } from '@/redux/store';
 import helpers from '@/utils/helpers';
 import { Player as PlayerType } from '@/utils/types';
 import {
-	ArrowDownwardSharp as ArrowDownwardSharpIcon,
-	ArrowUpward as ArrowUpwardIcon,
 	DragIndicator as DragIndicatorIcon,
+	Remove as RemoveIcon,
 	Speed as SpeedIcon,
+	TrendingDown as TrendingDownIcon,
+	TrendingUp as TrendingUpIcon,
 } from '@mui/icons-material';
 import {
 	Avatar,
@@ -85,7 +86,7 @@ function Player({ player, onRename, dragHandleProps, isDragEnabled }: Props) {
 					<DragIndicatorIcon sx={styles.dragIcon} />
 				</Box>
 			)}
-			<Stack sx={styles.wrapper}>
+			<Stack sx={styles.wrapper(player.autoFill)}>
 				<Stack sx={styles.row}>
 					<Stack
 						direction="row"
@@ -114,8 +115,9 @@ function Player({ player, onRename, dragHandleProps, isDragEnabled }: Props) {
 						{currentGameNumber !== 1 && !isFinished && (
 							<Stack sx={styles.trendWrapper(increasingTrendValue)}>
 								<Box>{`(`}</Box>
-								{increasingTrendValue >= 0 && <ArrowUpwardIcon sx={styles.trendIndicator} />}
-								{increasingTrendValue < 0 && <ArrowDownwardSharpIcon sx={styles.trendIndicator} />}
+								{increasingTrendValue > 0 && <TrendingUpIcon sx={styles.trendIndicator} />}
+								{increasingTrendValue === 0 && <RemoveIcon sx={styles.trendIndicator} />}
+								{increasingTrendValue < 0 && <TrendingDownIcon sx={styles.trendIndicator} />}
 								<Typography sx={styles.trendMetric}>{increasingTrendValue}</Typography>
 								<Box>{`)`}</Box>
 							</Stack>

--- a/src/pages/PlayingPage/components/Player/styles.ts
+++ b/src/pages/PlayingPage/components/Player/styles.ts
@@ -3,14 +3,15 @@ import helpers from '@/utils/helpers';
 import { SxProps } from '@mui/material';
 
 const styles = {
-	wrapper: {
-		padding: '8px 12px',
-		gap: '4px',
-		border: `1px solid #1976d2`,
-		borderRadius: '0.5rem',
-		backgroundColor: '#FFF',
-		flex: 1,
-	} as SxProps,
+	wrapper: (autoFill?: boolean) =>
+		({
+			padding: '8px 12px',
+			gap: '4px',
+			border: `1px solid ${PRIMARY_COLOR}`,
+			borderRadius: '0.5rem',
+			backgroundColor: autoFill ? '#e3f2fd' : '#FFF',
+			flex: 1,
+		}) as SxProps,
 	row: {
 		flexDirection: 'row',
 		justifyContent: 'space-between',
@@ -43,7 +44,7 @@ const styles = {
 		({
 			flexDirection: 'row',
 			alignItems: 'center',
-			color: increasingTrendValue >= 0 ? '#008000' : '#D32F2F',
+			color: increasingTrendValue > 0 ? '#008000' : increasingTrendValue < 0 ? '#D32F2F' : '#888',
 			fontSize: '14px',
 		}) as SxProps,
 	trendIndicator: {


### PR DESCRIPTION
  - Replace arrow icons with TrendingUp/TrendingDown/Remove for clearer trend display
  - Add neutral state (gray) for zero trend value instead of grouping with positive
  - Highlight autofill players with light blue background
  - Use PRIMARY_COLOR constant instead of hardcoded border color