### PR TITLE
fix(player): allow comma-separated player names in create mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,12 +34,12 @@ npm run pre-commit   # Lint + format (used by Husky)
 
 ```typescript
 interface Player {
-  id: number;        // Timestamp-based ID (dayjs().valueOf())
-  name: string;
-  scores: number[];  // Index = game number (0-indexed)
-  gap?: number;      // Per-player gap override
-  autoFill?: boolean; // Auto-fill flag (highlighted, disabled from scoring)
-  avatar?: string;   // Base64-encoded profile image
+	id: number; // Timestamp-based ID (dayjs().valueOf())
+	name: string;
+	scores: number[]; // Index = game number (0-indexed)
+	gap?: number; // Per-player gap override
+	autoFill?: boolean; // Auto-fill flag (highlighted, disabled from scoring)
+	avatar?: string; // Base64-encoded profile image
 }
 ```
 

--- a/src/components/PlayerModifierDialog/PlayerModifierDialog.tsx
+++ b/src/components/PlayerModifierDialog/PlayerModifierDialog.tsx
@@ -118,6 +118,14 @@ const PlayerModifierDialog = forwardRef(
 			}
 
 			if (mode === Mode.Edit) {
+				if (value.length < PLAYER_NAME.MIN_LENGTH || value.length > PLAYER_NAME.MAX_LENGTH) {
+					const message = t('validation.playerName.length', {
+						min: PLAYER_NAME.MIN_LENGTH,
+						max: PLAYER_NAME.MAX_LENGTH,
+					});
+					setError('name', { message });
+					return;
+				}
 				onSubmit(value, editedPlayerRef.current?.id);
 			}
 

--- a/src/components/PlayerModifierDialog/schema.ts
+++ b/src/components/PlayerModifierDialog/schema.ts
@@ -13,12 +13,5 @@ export const schema = yup.object().shape({
 				max: PLAYER_NAME.MAX_LENGTH,
 			}),
 		)
-		.max(
-			PLAYER_NAME.MAX_LENGTH,
-			i18n.t('validation.playerName.length', {
-				min: PLAYER_NAME.MIN_LENGTH,
-				max: PLAYER_NAME.MAX_LENGTH,
-			}),
-		)
 		.required(i18n.t('validation.playerName.required')),
 });


### PR DESCRIPTION

  Fix a bug where entering comma-separated player names (e.g. "Tuong Vy, Huu, Vu, Thien") in create mode was rejected by the Yup schema's max length
  constraint, which validated the entire input string instead of individual names.

  Changes

  - Remove .max() constraint from Yup schema in PlayerModifierDialog/schema.ts so comma-separated input passes through to per-name validation
  - Add explicit min/max length validation for Edit mode in PlayerModifierDialog.tsx
  - Format Player interface code block in CLAUDE.md

  How it works

  - Create mode: Yup only checks required + min. The comma-separated string is then split and each name is individually validated against
  PLAYER_NAME.MIN_LENGTH (2) and PLAYER_NAME.MAX_LENGTH (10)
  - Edit mode: Single name is validated against min/max length directly in onSubmitForm