### PR TITLE
feat(api): migrate to ghi-diem-api backend with realtime share and ad…

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,11 @@
+{
+	"version": "0.0.1",
+	"configurations": [
+		{
+			"name": "fe-dev",
+			"runtimeExecutable": "yarn",
+			"runtimeArgs": ["dev"],
+			"port": 5173
+		}
+	]
+}

--- a/.env.development
+++ b/.env.development
@@ -1,0 +1,2 @@
+# Local development: point the FE at the backend running via docker compose.
+VITE_API_URL=http://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+# Base URL for the Ghi Điểm backend API (Django Ninja).
+# The app falls back to http://localhost:8000 when this is unset.
+VITE_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 [![React](https://img.shields.io/badge/React-18-61dafb.svg)](https://reactjs.org/)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 
-A Vietnamese score-tracking web application for multi-player card games. Create matches, add players, track scores across multiple games, and view leaderboards - all persisted locally in your browser.
+A Vietnamese score-tracking web application for multi-player card games. Create matches, add players, track scores across multiple games, and share a live scoreboard with anyone via a link. Backed by the [ghi-diem-api](https://github.com/GaryHuu/ghi-diem-api) REST + WebSocket backend.
 
 🔗 **Live Demo**: [https://www.ghidiem.online/](https://www.ghidiem.online/)
 
@@ -13,7 +13,11 @@ A Vietnamese score-tracking web application for multi-player card games. Create 
 
 - ✅ **Match Management** - Create and manage multiple game matches
 - 👥 **Player Tracking** - Add unlimited players with unique names and avatars
-- 🎯 **Zero-Sum Validation** - Enforces score balance (all scores must sum to zero)
+- 🎯 **Zero-Sum Validation** - Enforces score balance (all scores must sum to zero), validated server-side
+- 📡 **Live Share** - Permanent read-only share link; viewers see score updates in realtime over WebSocket and can browse past rounds
+- 🕘 **Shared History** - Quick access to shared scoreboards you have viewed before
+- ⚡ **Optimistic Scoring** - Score edits apply instantly in the UI and sync to the API in the background
+- 🛡️ **Admin Dashboard** - `/dashboard` login for browsing all matches (read-only)
 - 📊 **Real-time Leaderboard** - Live rankings and statistics
 - 💸 **Transaction Visualization** - Interactive payment flow chart between players using React Flow
 - 🔄 **Drag & Drop** - Reorder players easily during gameplay
@@ -22,7 +26,6 @@ A Vietnamese score-tracking web application for multi-player card games. Create 
 - 🎛️ **Per-Player Gap Setting** - Override global gap setting for individual players
 - 🖼️ **Player Avatars** - Upload and display player profile images
 - 📐 **UI Modes** - Switch between compact and full interface layouts
-- 💾 **Offline-First** - All data persisted in browser localStorage
 - 📱 **Responsive Design** - Works seamlessly on mobile and desktop
 - 🌐 **Internationalization (i18n)** - Vietnamese (English temporarily disabled)
 
@@ -33,6 +36,12 @@ A Vietnamese score-tracking web application for multi-player card games. Create 
 - **React 18** - UI framework with TypeScript
 - **Vite** - Lightning-fast build tool and dev server
 - **TypeScript 5.5** - Type-safe development
+
+### Backend Integration
+
+- **[ghi-diem-api](https://github.com/GaryHuu/ghi-diem-api)** - Django Ninja REST API + Channels WebSocket
+- **Native fetch** - No HTTP client dependency; device identity via `X-Device-Id` header
+- **Native WebSocket** - Realtime share view with auto-reconnect
 
 ### State & Routing
 
@@ -69,28 +78,36 @@ A Vietnamese score-tracking web application for multi-player card games. Create 
 
 ### Prerequisites
 
-- Node.js 18+
-- npm or yarn
+- Node.js 20 (see `.nvmrc`)
+- yarn
+- A running [ghi-diem-api](https://github.com/GaryHuu/ghi-diem-api) backend (one `docker compose up` in that repo)
 
 ### Installation
 
 1. Clone the repository
 
 ```bash
-git clone https://github.com/yourusername/ghi-diem-online.git
+git clone https://github.com/GaryHuu/ghi-diem-online.git
 cd ghi-diem-online
 ```
 
 2. Install dependencies
 
 ```bash
-npm install
+yarn install
 ```
 
-3. Start development server
+3. Configure the API endpoint (optional for local dev)
 
 ```bash
-npm run dev
+cp .env.example .env.development
+# VITE_API_URL defaults to http://localhost:8000 when unset
+```
+
+4. Start the development server
+
+```bash
+yarn dev
 ```
 
 The app will be available at `http://localhost:5173`
@@ -98,97 +115,95 @@ The app will be available at `http://localhost:5173`
 ## Development Commands
 
 ```bash
-npm run dev          # Start development server (Vite)
-npm run build        # Build for production
-npm run preview      # Preview production build
-npm run lint         # Run ESLint
-npm run format       # Format code with Prettier
-npm run pre-commit   # Lint + format (used by Husky)
+yarn dev          # Start development server (Vite)
+yarn build        # Build for production
+yarn preview      # Preview production build
+yarn lint         # Run ESLint
+yarn format       # Format code with Prettier
+yarn pre-commit   # Lint + format (used by Husky)
 ```
 
 ## Project Structure
 
 ```
 src/
-├── components/          # Reusable UI components
+├── api/                # REST client (native fetch, X-Device-Id, admin endpoints)
+├── components/         # Reusable UI components
 │   ├── PlayerModifierDialog/  # Player create/edit dialog with avatar upload
 │   ├── SettingDialog/         # Settings (unit, gap, UI mode)
-│   └── ToastContainer/       # Toast notification wrapper
-├── db/                 # localStorage database layer
-│   ├── match/         # Match and player CRUD operations
-│   └── setting/       # User settings persistence
-├── hooks/             # Shared custom hooks
+│   └── ToastContainer/        # Toast notification wrapper
+├── db/                 # Data layer — thin async wrappers over the REST API
+├── hooks/              # Shared custom hooks
+│   ├── useShareSocket.ts      # WebSocket subscription for the live share view
 │   ├── useBoolean.ts
 │   ├── useFormatCurrency.ts
 │   ├── useScrollToTop.ts
 │   └── useAddQueryParams.ts
-├── i18n/              # Internationalization
-│   ├── locales/       # Translation files (en.json, vi.json)
-│   └── index.ts       # i18n configuration
-├── services/          # Business logic layer
-│   ├── match/        # Match validation and operations
-│   └── setting/      # Settings service
-├── redux/            # Redux state management
-│   └── slices/       # Redux slices (match, setting)
-├── pages/            # Route-level page components
-│   ├── HomePage/     # Landing page with match listing
-│   ├── CreatingPage/ # New match setup form
-│   └── PlayingPage/  # Active match scoring interface
-│       ├── components/
-│       │   ├── Player/        # Player card with score input, trend, autofill
-│       │   ├── Transactions/  # Payment flow visualization (React Flow)
-│       │   ├── TopOne/        # Winner display with crown
-│       │   └── LeaderBoard/   # Rankings table
-│       └── hooks/
-│           ├── usePlaying.ts          # Main match orchestration hook
-│           ├── usePlayingFetcher.ts   # Data fetching logic
-│           ├── useDraggablePlayer.ts  # Drag and drop logic
-│           └── useTransactions.ts     # Payment flow calculation
-├── routes/           # React Router configuration
-├── utils/            # Shared utilities and types
-└── migration.js      # Data migration for backward compatibility
+├── i18n/               # Internationalization (locales: en.json, vi.json)
+├── services/           # Business logic layer
+├── redux/              # Redux state management (match, setting slices)
+├── pages/              # Route-level page components
+│   ├── HomePage/       # Landing page with match listing + shared history
+│   ├── CreatingPage/   # New match setup form
+│   ├── PlayingPage/    # Active match scoring interface
+│   │   ├── components/ # Player, LeaderBoard, Transactions, TopOne, ShareLinkDialog...
+│   │   └── hooks/      # usePlaying, usePlayingFetcher, useDraggablePlayer...
+│   ├── SharedViewPage/ # Read-only live share view (/share/:token)
+│   └── DashboardPage/  # Admin dashboard (/dashboard)
+├── routes/             # React Router configuration
+├── utils/              # Shared utilities, types, helpers (deviceId, shareHistory...)
+└── migration.js        # Legacy localStorage migration for settings
 ```
 
 ## Architecture Overview
 
 ### Data Layer
 
-The application uses a **localStorage-based database** instead of a traditional backend:
+The app talks to the [ghi-diem-api](https://github.com/GaryHuu/ghi-diem-api) backend:
 
-- **Database Layer** (`src/db/`) - Direct localStorage operations
-- **Service Layer** (`src/services/`) - Business logic and validation
-- **Redux Store** (`src/redux/`) - Global state management
+- **API Client** (`src/api/`) - Native fetch wrapper; attaches the `X-Device-Id` header
+- **Database Layer** (`src/db/`) - Async CRUD calls to the REST API
+- **Service Layer** (`src/services/`) - Client-side validation and orchestration
+- **Redux Store** (`src/redux/`) - Global state, hydrated from API responses
 
-### Key Routing
+Ownership is anonymous: a UUID generated once per browser (`deviceId` in localStorage) identifies the device. Matches created on a device can only be modified by that device; share links are read-only for everyone else.
 
-1. **HomePage** (`/`) - Match listing and creation
-2. **CreatingPage** (`/creating`) - New match setup
-3. **PlayingPage** (`/match?id=<matchId>&gN=<gameNumber>`) - Active gameplay
+### Routing
+
+1. **HomePage** (`/`) - Match listing, shared history, and creation
+2. **CreatingPage** (`/match/create`) - New match setup
+3. **PlayingPage** (`/match/:id?gN=<gameNumber>`) - Active gameplay
+4. **SharedViewPage** (`/share/:token`) - Public read-only live scoreboard (WebSocket)
+5. **DashboardPage** (`/dashboard`) - Admin login + read-only match browser
 
 ### Zero-Sum Score Validation
 
-The core constraint of the app is that **all player scores for each game must sum to zero**. This enforces traditional Vietnamese card game rules where points are transferred between players.
+The core constraint of the app is that **all player scores for each game must sum to zero**. This enforces traditional Vietnamese card game rules where points are transferred between players. Validation runs server-side when advancing or ending a game.
+
+### Live Share
+
+The match owner generates a permanent share link. Viewers get the full match view (scores per round, leaderboard, transactions) in read-only mode, updated in realtime through a WebSocket. Viewers can browse earlier rounds; when the owner advances the game, viewers sitting on the latest round follow automatically.
 
 ### Player Data Model
 
-Each player has the following structure:
-
-- `id` - Timestamp-based unique identifier
+- `id` - Server-generated identifier
 - `name` - Display name
 - `scores[]` - Array of scores indexed by game number
 - `gap?` - Optional per-player gap override
 - `autoFill?` - Flag for automatic score filling
 - `avatar?` - Base64-encoded profile image
 
-## Data Persistence
+## Local Storage
 
-All data is stored in browser **localStorage** with the following keys:
+Only lightweight client state lives in localStorage:
 
-- `GHIDIEM_ONLINE_KEY` - Match data
-- `GHIDIEM_ONLINE_SETTING_KEY` - User settings (unit, gap, UI mode)
-- `i18nextLng` - Cached language preference for i18next
+- `deviceId` - Anonymous device identity (UUID)
+- `SETTING` - User settings (unit, gap, UI mode)
+- `sharedHistory` - Recently viewed shared scoreboards
+- `adminToken` - Admin dashboard session token
+- `i18nextLng` - Cached language preference
 
-The app includes automatic data migration (`src/migration.js`) to handle schema changes between versions, including migration for new fields like `uiMode`.
+Match data is stored by the backend.
 
 ### Internationalization
 
@@ -216,8 +231,8 @@ Contributions are welcome! Please follow these steps:
 
 ### Code Style
 
-- Run `npm run format` before committing
-- Ensure `npm run lint` passes
+- Run `yarn format` before committing
+- Ensure `yarn lint` passes
 - Follow existing TypeScript patterns and component structure
 
 ## License
@@ -229,7 +244,3 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 - Built with ❤️ for Vietnamese card game enthusiasts
 - Inspired by traditional score-keeping methods
 - Powered by modern web technologies
-
----
-
-**Note**: This is a client-side only application with no backend server. All data is stored locally in your browser.

--- a/src/api/admin.ts
+++ b/src/api/admin.ts
@@ -1,0 +1,61 @@
+import { Match } from '@/utils/types';
+import apiClient, { ApiError } from './client';
+
+export const ADMIN_TOKEN_KEY = 'adminToken';
+
+export interface AdminMatchSummary {
+	id: number;
+	name: string;
+	isFinished: boolean;
+	total: number;
+	playerCount: number;
+	createdAt: string;
+}
+
+export interface AdminMatchDetail extends Match {
+	total: number;
+	current: number;
+}
+
+export class AdminAuthError extends Error {}
+
+const authHeaders = (): Record<string, string> => ({
+	Authorization: `Bearer ${localStorage.getItem(ADMIN_TOKEN_KEY) ?? ''}`,
+});
+
+const withAuthGuard = async <T>(fn: () => Promise<T>): Promise<T> => {
+	try {
+		return await fn();
+	} catch (error) {
+		if (error instanceof ApiError && error.status === 401) {
+			localStorage.removeItem(ADMIN_TOKEN_KEY);
+			throw new AdminAuthError('errors.unauthorized');
+		}
+		throw error;
+	}
+};
+
+export const adminLogin = async (username: string, password: string): Promise<string> => {
+	const { token } = await apiClient.post<{ token: string }>(
+		'/api/admin/login',
+		{ username, password },
+		{ skipDeviceId: true },
+	);
+	return token;
+};
+
+export const adminGetMatches = (): Promise<AdminMatchSummary[]> =>
+	withAuthGuard(() =>
+		apiClient.get<AdminMatchSummary[]>('/api/admin/matches', {
+			skipDeviceId: true,
+			headers: authHeaders(),
+		}),
+	);
+
+export const adminGetMatch = (id: number): Promise<AdminMatchDetail> =>
+	withAuthGuard(() =>
+		apiClient.get<AdminMatchDetail>(`/api/admin/matches/${id}`, {
+			skipDeviceId: true,
+			headers: authHeaders(),
+		}),
+	);

--- a/src/api/client.ts
+++ b/src/api/client.ts
@@ -1,0 +1,71 @@
+import { getDeviceId } from '@/utils/helpers';
+
+export const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+
+type RequestOptions = {
+	method?: string;
+	body?: unknown;
+	skipDeviceId?: boolean;
+	headers?: Record<string, string>;
+};
+
+export class ApiError extends Error {
+	status: number;
+
+	constructor(message: string, status: number) {
+		super(message);
+		this.name = 'ApiError';
+		this.status = status;
+	}
+}
+
+const request = async <T>(path: string, options: RequestOptions = {}): Promise<T> => {
+	const { method = 'GET', body, skipDeviceId } = options;
+
+	const headers: Record<string, string> = {
+		'Content-Type': 'application/json',
+		...options.headers,
+	};
+	if (!skipDeviceId) {
+		headers['X-Device-Id'] = getDeviceId();
+	}
+
+	let response: Response;
+	try {
+		response = await fetch(`${API_BASE_URL}${path}`, {
+			method,
+			headers,
+			body: body === undefined ? undefined : JSON.stringify(body),
+		});
+	} catch {
+		throw new Error('errors.network');
+	}
+
+	if (!response.ok) {
+		let message = 'errors.unknown';
+		try {
+			const errorBody = await response.json();
+			message = errorBody.detail || errorBody.message || message;
+		} catch {
+			// Response body is not JSON, keep the default message
+		}
+		throw new ApiError(message, response.status);
+	}
+
+	if (response.status === 204) {
+		return undefined as T;
+	}
+
+	return response.json() as Promise<T>;
+};
+
+const apiClient = {
+	get: <T>(path: string, options?: RequestOptions): Promise<T> =>
+		request<T>(path, { ...options, method: 'GET' }),
+	post: <T>(path: string, body?: unknown, options?: RequestOptions): Promise<T> =>
+		request<T>(path, { ...options, method: 'POST', body }),
+	put: <T>(path: string, body?: unknown): Promise<T> => request<T>(path, { method: 'PUT', body }),
+	delete: <T>(path: string): Promise<T> => request<T>(path, { method: 'DELETE' }),
+};
+
+export default apiClient;

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -1,0 +1,2 @@
+export { default as apiClient, API_BASE_URL, ApiError } from './client';
+export * from './admin';

--- a/src/components/PlayerModifierDialog/PlayerModifierDialog.tsx
+++ b/src/components/PlayerModifierDialog/PlayerModifierDialog.tsx
@@ -21,8 +21,8 @@ import { Mode, PlayerForm } from './types';
 
 type Props = {
 	children: ReactNode;
-	onSubmit?: (name: string, id?: number) => void;
-	onAvatarChange?: (playerId: number, avatar?: string) => void;
+	/** avatar: Base64 string, null to remove, undefined when unchanged */
+	onSubmit?: (name: string, id?: number, avatar?: string | null) => void;
 };
 
 export type PlayerModifierDialogRefType = {
@@ -54,14 +54,12 @@ const resizeImage = (file: File): Promise<string> => {
 };
 
 const PlayerModifierDialog = forwardRef(
-	(
-		{ children, onSubmit = () => {}, onAvatarChange }: Props,
-		ref: Ref<PlayerModifierDialogRefType>,
-	) => {
+	({ children, onSubmit = () => {} }: Props, ref: Ref<PlayerModifierDialogRefType>) => {
 		const { t } = useTranslation();
 		const [mode, setMode] = useState<Mode>(Mode.Create);
 		const [isOpen, setIsOpen] = useState(false);
 		const [avatarPreview, setAvatarPreview] = useState<string | undefined>();
+		const avatarDirtyRef = useRef(false);
 		const editedPlayerRef = useRef<PlayerForm | null>(null);
 		const fileInputRef = useRef<HTMLInputElement>(null);
 
@@ -84,6 +82,7 @@ const PlayerModifierDialog = forwardRef(
 			reset();
 			setMode(Mode.Create);
 			setAvatarPreview(undefined);
+			avatarDirtyRef.current = false;
 			editedPlayerRef.current = null;
 			helpers.scrollToTop();
 		};
@@ -126,7 +125,11 @@ const PlayerModifierDialog = forwardRef(
 					setError('name', { message });
 					return;
 				}
-				onSubmit(value, editedPlayerRef.current?.id);
+				onSubmit(
+					value,
+					editedPlayerRef.current?.id,
+					avatarDirtyRef.current ? (avatarPreview ?? null) : undefined,
+				);
 			}
 
 			handleClose();
@@ -136,24 +139,22 @@ const PlayerModifierDialog = forwardRef(
 			fileInputRef.current?.click();
 		};
 
-		const handleFileChange = useCallback(
-			async (e: React.ChangeEvent<HTMLInputElement>) => {
-				const file = e.target.files?.[0];
-				if (!file || !editedPlayerRef.current?.id) return;
+		const handleFileChange = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+			const file = e.target.files?.[0];
+			if (!file || !editedPlayerRef.current?.id) return;
 
-				const base64 = await resizeImage(file);
-				setAvatarPreview(base64);
-				onAvatarChange?.(editedPlayerRef.current.id, base64);
+			// Preview only -- persisted together with the name on submit.
+			const base64 = await resizeImage(file);
+			setAvatarPreview(base64);
+			avatarDirtyRef.current = true;
 
-				if (fileInputRef.current) fileInputRef.current.value = '';
-			},
-			[onAvatarChange],
-		);
+			if (fileInputRef.current) fileInputRef.current.value = '';
+		}, []);
 
 		const handleRemoveAvatar = () => {
 			if (!editedPlayerRef.current?.id) return;
 			setAvatarPreview(undefined);
-			onAvatarChange?.(editedPlayerRef.current.id, undefined);
+			avatarDirtyRef.current = true;
 		};
 
 		useImperativeHandle(ref, () => ({
@@ -162,6 +163,7 @@ const PlayerModifierDialog = forwardRef(
 				setMode(Mode.Edit);
 				setValue('name', player?.name ?? '');
 				setAvatarPreview(player?.avatar);
+				avatarDirtyRef.current = false;
 				editedPlayerRef.current = player;
 			},
 		}));

--- a/src/db/match/index.ts
+++ b/src/db/match/index.ts
@@ -1,229 +1,72 @@
-import { DB_KEYS } from '@/utils/constants';
-import { Match, MatchWithoutPlayers, Player } from '@/utils/types';
-import {
-	getFromLocalStorage,
-	setToLocalStorage,
-	removeFromLocalStorage,
-	getKeyStoragePlayersOfMatch,
-} from '@/utils/helpers';
+import { apiClient } from '@/api';
+import { Match, Player } from '@/utils/types';
 
-/**
- * Gets all match metadata from localStorage
- * @returns Array of match metadata without players
- */
-const getMatchesMetadata = (): MatchWithoutPlayers[] => {
-	return getFromLocalStorage<MatchWithoutPlayers[]>(DB_KEYS.MY_IDS_OF_MATCHES, []);
+// avatar: null explicitly clears it server-side (undefined would be dropped by JSON.stringify)
+type PlayerUpdate = Partial<Pick<Player, 'name' | 'gap'>> & {
+	avatar?: string | null;
+	order?: number;
 };
 
-/**
- * Saves match metadata to localStorage
- * @param matchesMetadata - Array of match metadata to save
- */
-const saveMatchesMetadata = (matchesMetadata: MatchWithoutPlayers[]): void => {
-	setToLocalStorage(DB_KEYS.MY_IDS_OF_MATCHES, matchesMetadata);
-};
+const getMatches = (): Promise<Match[]> => apiClient.get<Match[]>('/api/matches');
 
-/**
- * Gets players for a specific match from localStorage
- * @param matchId - The match ID
- * @returns Array of players
- */
-const getMatchPlayers = (matchId: number): Player[] => {
-	return getFromLocalStorage<Player[]>(getKeyStoragePlayersOfMatch(matchId), []);
-};
+const getMatch = (id: number): Promise<Match> => apiClient.get<Match>(`/api/matches/${id}`);
 
-/**
- * Saves players for a specific match to localStorage
- * @param matchId - The match ID
- * @param players - Array of players to save
- */
-const saveMatchPlayers = (matchId: number, players: Player[]): void => {
-	setToLocalStorage(getKeyStoragePlayersOfMatch(matchId), players);
-};
+const createMatch = (name: string): Promise<Match> =>
+	apiClient.post<Match>('/api/matches', { name, players: [] });
 
-/**
- * Checks if a player name already exists in the match (case-insensitive)
- * @param players - Array of existing players
- * @param name - Name to check
- * @param excludePlayerId - Optional player ID to exclude from check (for updates)
- * @returns true if name exists
- */
-const isPlayerNameDuplicate = (
-	players: Player[],
-	name: string,
-	excludePlayerId?: number,
-): boolean => {
-	return players.some(
-		(p) =>
-			p.name.trim().toLowerCase() === name.trim().toLowerCase() &&
-			(!excludePlayerId || p.id !== excludePlayerId),
-	);
-};
+const deleteMatch = (id: number): Promise<void> => apiClient.delete<void>(`/api/matches/${id}`);
 
-/**
- * Creates a new match
- * @param newMatchBasicInfo - Match metadata
- * @returns The created match with empty players array
- */
-const createMatch = (newMatchBasicInfo: MatchWithoutPlayers): Match => {
-	const matchesMetadata = getMatchesMetadata();
-	matchesMetadata.unshift(newMatchBasicInfo);
-	saveMatchesMetadata(matchesMetadata);
-	saveMatchPlayers(newMatchBasicInfo.id, []);
+const addPlayerToMatch = (matchId: number, name: string): Promise<Match> =>
+	apiClient.post<Match>(`/api/matches/${matchId}/players`, { name });
 
-	return {
-		...newMatchBasicInfo,
-		players: [],
-	};
-};
+const updatePlayer = (matchId: number, playerId: number, data: PlayerUpdate): Promise<Match> =>
+	apiClient.put<Match>(`/api/matches/${matchId}/players/${playerId}`, data);
 
-/**
- * Updates match metadata
- * @param match - Match metadata to update
- * @returns Updated match metadata or undefined if not found
- */
-const updateMatch = (match: MatchWithoutPlayers): MatchWithoutPlayers | undefined => {
-	const matchesMetadata = getMatchesMetadata();
-	const index = matchesMetadata.findIndex((m) => m.id === match.id);
+const updateScore = (
+	matchId: number,
+	playerId: number,
+	gameIndex: number,
+	value: number,
+): Promise<Match> =>
+	apiClient.put<Match>(`/api/matches/${matchId}/scores`, { playerId, gameIndex, value });
 
-	if (index === -1) return undefined;
-
-	matchesMetadata[index] = {
-		id: match.id,
-		name: match.name,
-		isFinished: match.isFinished,
-	};
-	saveMatchesMetadata(matchesMetadata);
-
-	return matchesMetadata[index];
-};
-
-/**
- * Gets a match by ID with its players
- * @param id - Match ID
- * @returns Match with players or undefined if not found
- */
-const getMatch = (id: number): Match | undefined => {
-	const matchesMetadata = getMatchesMetadata();
-	const matchMetadata = matchesMetadata.find((m) => m.id === id);
-
-	if (!matchMetadata) return undefined;
-
-	const players = getMatchPlayers(matchMetadata.id);
-
-	return {
-		...matchMetadata,
-		players,
-	};
-};
-
-/**
- * Gets all matches with their players
- * @returns Array of all matches
- */
-const getMatches = (): Match[] => {
-	const matchesMetadata = getMatchesMetadata();
-
-	return matchesMetadata.map((matchMetadata) => {
-		const players = getMatchPlayers(matchMetadata.id);
-		return { ...matchMetadata, players };
-	});
-};
-
-/**
- * Adds a player to a match
- * @param id - Match ID
- * @param player - Player to add
- * @returns The added player or undefined if name already exists
- */
-const addPlayerToMatch = (id: number, player: Player): Player | undefined => {
-	const players = getMatchPlayers(id);
-
-	if (isPlayerNameDuplicate(players, player.name)) {
-		return undefined;
+const updatePlayersPosition = async (matchId: number, players: Player[]): Promise<Match> => {
+	let match: Match | undefined;
+	for (let index = 0; index < players.length; index++) {
+		match = await updatePlayer(matchId, players[index].id, { order: index });
 	}
-
-	players.push(player);
-	saveMatchPlayers(id, players);
-
-	return player;
+	return match ?? getMatch(matchId);
 };
 
-/**
- * Gets a specific player from a match
- * @param matchId - Match ID
- * @param playerId - Player ID
- * @returns Player or undefined if not found
- */
-const getPlayerOfMatch = (matchId: number, playerId: number): Player | undefined => {
-	const players = getMatchPlayers(matchId);
-	return players.find((p) => p.id === playerId);
-};
+const toggleAutoFill = (matchId: number, playerId: number): Promise<Match> =>
+	apiClient.post<Match>(`/api/matches/${matchId}/players/${playerId}/toggle-autofill`);
 
-/**
- * Updates a player in a match
- * @param matchId - Match ID
- * @param player - Updated player data
- * @returns Updated player or undefined if not found or name is duplicate
- */
-const updatePlayerOfMatch = (matchId: number, player: Player): Player | undefined => {
-	const players = getMatchPlayers(matchId);
+const nextGame = (id: number): Promise<Match> =>
+	apiClient.post<Match>(`/api/matches/${id}/next-game`);
 
-	if (isPlayerNameDuplicate(players, player.name, player.id)) {
-		return undefined;
-	}
+const endGame = (id: number): Promise<Match> =>
+	apiClient.post<Match>(`/api/matches/${id}/end-game`);
 
-	const index = players.findIndex((p) => p.id === player.id);
-	if (index === -1) return undefined;
+const shareMatch = (id: number): Promise<{ token: string }> =>
+	apiClient.post<{ token: string }>(`/api/matches/${id}/share`);
 
-	players[index] = player;
-	saveMatchPlayers(matchId, players);
-
-	return player;
-};
-
-/**
- * Updates all players in a match
- * @param id - Match ID
- * @param players - Updated players array
- * @returns Updated players array
- */
-const updatePlayersOfMatch = (id: number, players: Player[]): Player[] => {
-	saveMatchPlayers(id, players);
-	return players;
-};
-
-/**
- * Deletes a match and its players
- * @param id - Match ID
- */
-const deleteMatch = (id: number): void => {
-	const matchesMetadata = getMatchesMetadata();
-	const newMatchesMetadata = matchesMetadata.filter((match) => match.id !== id);
-	saveMatchesMetadata(newMatchesMetadata);
-	removeFromLocalStorage(getKeyStoragePlayersOfMatch(id));
-};
-
-/**
- * Updates the order/position of players in a match
- * @param id - Match ID
- * @param players - Reordered players array
- */
-const updatePlayersPositionOfMatch = (id: number, players: Player[]): void => {
-	saveMatchPlayers(id, players);
-};
+const getSharedMatch = (token: string): Promise<Match> =>
+	apiClient.get<Match>(`/api/shared/${token}`, { skipDeviceId: true });
 
 const matchDB = {
-	createMatch,
-	updateMatch,
-	getMatch,
 	getMatches,
-	addPlayerToMatch,
-	getPlayerOfMatch,
-	updatePlayerOfMatch,
-	updatePlayersOfMatch,
+	getMatch,
+	createMatch,
 	deleteMatch,
-	updatePlayersPositionOfMatch,
+	addPlayerToMatch,
+	updatePlayer,
+	updateScore,
+	updatePlayersPosition,
+	toggleAutoFill,
+	nextGame,
+	endGame,
+	shareMatch,
+	getSharedMatch,
 };
 
 export default matchDB;

--- a/src/declarations.d.ts
+++ b/src/declarations.d.ts
@@ -1,3 +1,11 @@
+interface ImportMetaEnv {
+	readonly VITE_API_URL?: string;
+}
+
+interface ImportMeta {
+	readonly env: ImportMetaEnv;
+}
+
 declare module '*.module.scss' {
 	const content: { [className: string]: string };
 	export default content;

--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -2,3 +2,4 @@ export { default as useScrollToTop } from './useScrollToTop';
 export { default as useBoolean } from './useBoolean';
 export { default as useAddQueryParams } from './useAddQueryParams';
 export { default as useFormatCurrency } from './useFormatCurrency';
+export { default as useShareSocket } from './useShareSocket';

--- a/src/hooks/useShareSocket.ts
+++ b/src/hooks/useShareSocket.ts
@@ -1,0 +1,118 @@
+import { API_BASE_URL } from '@/api';
+import { useAppDispatch, useAppSelector } from '@/redux/hooks';
+import { updateMatchDetail } from '@/redux/slices/matchSlice';
+import { RootState } from '@/redux/store';
+import { Match } from '@/utils/types';
+import { useEffect, useRef } from 'react';
+
+const MAX_BACKOFF_MS = 10000;
+
+const getSocketUrl = (token: string): string => {
+	const base = API_BASE_URL.replace(/^http/, 'ws');
+	return `${base}/ws/share/${token}`;
+};
+
+/**
+ * Subscribes to live match snapshots for a shared token via WebSocket.
+ * Score-path snapshots exclude avatars (kept light); the connect snapshot and
+ * player add/update broadcasts include them. Cached avatars fill the gaps.
+ */
+function useShareSocket(token?: string) {
+	const dispatch = useAppDispatch();
+	const players = useAppSelector((state: RootState) => state.match.matchDetail?.data.players);
+	const isShowResult = useAppSelector(
+		(state: RootState) => state.match.matchDetail?.isShowResult ?? false,
+	);
+
+	const current = useAppSelector((state: RootState) => state.match.matchDetail?.current);
+	const total = useAppSelector((state: RootState) => state.match.matchDetail?.total);
+
+	const avatarMapRef = useRef<Record<number, string | undefined>>({});
+	const isShowResultRef = useRef(isShowResult);
+	const positionRef = useRef({ current, total });
+
+	useEffect(() => {
+		positionRef.current = { current, total };
+	}, [current, total]);
+
+	useEffect(() => {
+		players?.forEach((player) => {
+			if (player.avatar) avatarMapRef.current[player.id] = player.avatar;
+			else delete avatarMapRef.current[player.id];
+		});
+	}, [players]);
+
+	useEffect(() => {
+		isShowResultRef.current = isShowResult;
+	}, [isShowResult]);
+
+	useEffect(() => {
+		if (!token) return;
+
+		let socket: WebSocket | null = null;
+		let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
+		let retry = 0;
+		let isClosed = false;
+
+		const connect = () => {
+			socket = new WebSocket(getSocketUrl(token));
+
+			socket.onopen = () => {
+				retry = 0;
+			};
+
+			socket.onmessage = (event) => {
+				try {
+					const envelope = JSON.parse(event.data);
+					if (envelope.type !== 'match.snapshot') return;
+
+					const data = envelope.data as Match;
+					const merged: Match = {
+						...data,
+						players: data.players.map((player) => ({
+							...player,
+							// Key present (even null) = authoritative, e.g. avatar removed;
+							// key absent = light score-path snapshot, fall back to cache.
+							avatar:
+								'avatar' in player ? (player.avatar ?? undefined) : avatarMapRef.current[player.id],
+						})),
+					};
+					const newTotal = merged.players.find(Boolean)?.scores.length || 1;
+					// Follow the live game only when the viewer is already at the
+					// latest round; keep their position while browsing older rounds.
+					const prev = positionRef.current;
+					const isAtLatest = !prev.current || !prev.total || prev.current >= prev.total;
+					const viewerCurrent = isAtLatest || !prev.current ? newTotal : prev.current;
+
+					dispatch(
+						updateMatchDetail({
+							current: viewerCurrent,
+							total: newTotal,
+							data: merged,
+							isShowResult: isShowResultRef.current,
+						}),
+					);
+				} catch {
+					// Ignore malformed messages
+				}
+			};
+
+			socket.onclose = () => {
+				if (isClosed) return;
+				retry += 1;
+				const delay = Math.min(1000 * 2 ** (retry - 1), MAX_BACKOFF_MS);
+				reconnectTimer = setTimeout(connect, delay);
+			};
+		};
+
+		connect();
+
+		return () => {
+			isClosed = true;
+			if (reconnectTimer) clearTimeout(reconnectTimer);
+			socket?.close();
+		};
+	}, [token, dispatch]);
+}
+
+export default useShareSocket;

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -52,6 +52,30 @@
 			"matchLabel": "Match: {{name}}",
 			"individualGap": "Individual increment/decrement",
 			"resetToGlobal": "Reset to default"
+		},
+		"shared": {
+			"liveBadge": "Live view",
+			"notFound": "Shared match not found"
+		},
+		"dashboard": {
+			"title": "Dashboard",
+			"username": "Username",
+			"password": "Password",
+			"login": "Log in",
+			"logout": "Log out",
+			"back": "Back",
+			"empty": "No matches yet",
+			"table": {
+				"name": "Match name",
+				"status": "Status",
+				"rounds": "Rounds",
+				"players": "Players",
+				"createdAt": "Created at"
+			},
+			"status": {
+				"playing": "Playing",
+				"finished": "Finished"
+			}
 		}
 	},
 	"components": {
@@ -85,7 +109,9 @@
 			"inProgress": "In Progress",
 			"finished": "Finished",
 			"noInProgress": "No matches in progress",
-			"noFinished": "No finished matches"
+			"noFinished": "No finished matches",
+			"shared": "Shared with you",
+			"noShared": "No shared matches viewed yet"
 		},
 		"emptyPlayer": {
 			"message": "You don't have any players yet.",
@@ -96,6 +122,14 @@
 			"shareAction": "Share",
 			"download": "Download",
 			"error": "Could not generate the image. Please try again."
+		},
+		"shareLink": {
+			"action": "Share live",
+			"title": "Share match",
+			"description": "Anyone with this link can watch the scoreboard live (view only).",
+			"copy": "Copy",
+			"copied": "Copied",
+			"close": "Close"
 		}
 	},
 	"errors": {
@@ -117,7 +151,10 @@
 			"invalidScore": "Invalid score",
 			"scoreNotZeroWithNumber": "Total score of game {{gameNumber}} does not equal 0",
 			"scoreNotZero": "Total score of current game does not equal 0"
-		}
+		},
+		"network": "Cannot reach the server. Please try again.",
+		"unauthorized": "Your session has expired. Please log in again.",
+		"unknown": "Something went wrong. Please try again."
 	},
 	"validation": {
 		"matchName": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -52,6 +52,30 @@
 			"matchLabel": "Trận: {{name}}",
 			"individualGap": "Giá trị tăng/giảm riêng",
 			"resetToGlobal": "Đặt lại về mặc định"
+		},
+		"shared": {
+			"liveBadge": "Đang xem trực tiếp",
+			"notFound": "Không tìm thấy trận đấu được chia sẻ"
+		},
+		"dashboard": {
+			"title": "Bảng điều khiển",
+			"username": "Tên đăng nhập",
+			"password": "Mật khẩu",
+			"login": "Đăng nhập",
+			"logout": "Đăng xuất",
+			"back": "Quay lại",
+			"empty": "Chưa có trận đấu nào",
+			"table": {
+				"name": "Tên trận",
+				"status": "Trạng thái",
+				"rounds": "Số ván",
+				"players": "Số người chơi",
+				"createdAt": "Ngày tạo"
+			},
+			"status": {
+				"playing": "Đang chơi",
+				"finished": "Đã kết thúc"
+			}
 		}
 	},
 	"components": {
@@ -85,7 +109,9 @@
 			"inProgress": "Đang diễn ra",
 			"finished": "Đã kết thúc",
 			"noInProgress": "Không có bất kỳ trận đấu nào đang diễn ra",
-			"noFinished": "Không có bất kỳ trận đấu nào đã kết thúc"
+			"noFinished": "Không có bất kỳ trận đấu nào đã kết thúc",
+			"shared": "Được chia sẻ với bạn",
+			"noShared": "Chưa xem trận được chia sẻ nào"
 		},
 		"emptyPlayer": {
 			"message": "Bạn chưa có bất kỳ người chơi nào.",
@@ -96,6 +122,14 @@
 			"shareAction": "Chia sẻ",
 			"download": "Tải ảnh",
 			"error": "Không thể tạo ảnh. Vui lòng thử lại."
+		},
+		"shareLink": {
+			"action": "Chia sẻ trực tiếp",
+			"title": "Chia sẻ trận đấu",
+			"description": "Bất kỳ ai có liên kết này đều có thể xem bảng điểm trực tiếp (chỉ xem).",
+			"copy": "Sao chép",
+			"copied": "Đã sao chép",
+			"close": "Đóng"
 		}
 	},
 	"errors": {
@@ -117,7 +151,10 @@
 			"invalidScore": "Điểm số không hợp lệ",
 			"scoreNotZeroWithNumber": "Tổng số điểm của ván đấu {{gameNumber}} không bằng 0",
 			"scoreNotZero": "Tổng số điểm của ván đấu hiện tại không bằng 0"
-		}
+		},
+		"network": "Không thể kết nối máy chủ. Vui lòng thử lại.",
+		"unauthorized": "Phiên đăng nhập đã hết hạn. Vui lòng đăng nhập lại.",
+		"unknown": "Đã có lỗi xảy ra. Vui lòng thử lại."
 	},
 	"validation": {
 		"matchName": {

--- a/src/pages/CreatingPage/hooks/useCreatingPage.ts
+++ b/src/pages/CreatingPage/hooks/useCreatingPage.ts
@@ -1,5 +1,5 @@
 import { useAppDispatch } from '@/redux/hooks';
-import { updateMatches } from '@/redux/slices/matchSlice';
+import { fetchMatches } from '@/redux/slices/matchSlice';
 import { ROUTES } from '@/routes/constants';
 import { matchService } from '@/services';
 import { translateError } from '@/utils/helpers';
@@ -19,12 +19,10 @@ function useCreatingPage() {
 		resolver: yupResolver(schema),
 	});
 
-	const onSubmit = (data: CreatingPageForm) => {
+	const onSubmit = async (data: CreatingPageForm) => {
 		try {
-			const newMatch = matchService.create(data.name);
-			const newMatches = matchService.getAll();
-
-			dispatch(updateMatches(newMatches));
+			const newMatch = await matchService.create(data.name);
+			dispatch(fetchMatches());
 
 			const path = generatePath(ROUTES.MATCH, { id: newMatch.id });
 			navigate(path);

--- a/src/pages/DashboardPage/DashboardPage.tsx
+++ b/src/pages/DashboardPage/DashboardPage.tsx
@@ -1,0 +1,178 @@
+import { ArrowBack as ArrowBackIcon, Logout as LogoutIcon } from '@mui/icons-material';
+import {
+	Box,
+	Button,
+	Chip,
+	CircularProgress,
+	IconButton,
+	Stack,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableRow,
+	TextField,
+	Typography,
+} from '@mui/material';
+import dayjs from 'dayjs';
+import { useTranslation } from 'react-i18next';
+import { LeaderBoard, Player, PlayingLayout } from '../PlayingPage/components';
+import { usePlaying } from '../PlayingPage/hooks';
+import { useDashboard } from './hooks';
+import styles from './styles';
+
+function DashboardPage() {
+	const { t } = useTranslation();
+	const { match } = usePlaying();
+	const {
+		view,
+		username,
+		password,
+		matches,
+		isSubmitting,
+		isLoadingList,
+		isLoadingDetail,
+		setUsername,
+		setPassword,
+		login,
+		logout,
+		openMatch,
+		backToList,
+	} = useDashboard();
+
+	if (view === 'login') {
+		return (
+			<Box
+				component="form"
+				sx={styles.loginWrapper}
+				onSubmit={(event) => {
+					event.preventDefault();
+					login();
+				}}
+			>
+				<Typography sx={styles.loginTitle}>{t('pages.dashboard.title')}</Typography>
+				<TextField
+					label={t('pages.dashboard.username')}
+					value={username}
+					onChange={(event) => setUsername(event.target.value)}
+					autoComplete="username"
+					fullWidth
+				/>
+				<TextField
+					label={t('pages.dashboard.password')}
+					type="password"
+					value={password}
+					onChange={(event) => setPassword(event.target.value)}
+					autoComplete="current-password"
+					fullWidth
+				/>
+				<Button type="submit" variant="contained" disabled={isSubmitting}>
+					{t('pages.dashboard.login')}
+				</Button>
+			</Box>
+		);
+	}
+
+	if (view === 'detail') {
+		if (isLoadingDetail || !match) {
+			return (
+				<Box sx={styles.stateWrapper}>
+					<CircularProgress />
+				</Box>
+			);
+		}
+
+		return (
+			<PlayingLayout>
+				<Stack
+					sx={styles.header}
+					direction="row"
+					alignItems="center"
+					justifyContent="space-between"
+					gap="12px"
+				>
+					<IconButton color="primary" onClick={backToList} aria-label={t('pages.dashboard.back')}>
+						<ArrowBackIcon />
+					</IconButton>
+					<Stack sx={{ minWidth: 0, flex: 1 }}>
+						<Typography sx={styles.matchTitle}>
+							{t('pages.playing.matchLabel', { name: match.data.name })}
+						</Typography>
+						<Box sx={styles.roundPill}>
+							<Typography sx={styles.roundPillText}>
+								{t('pages.playing.roundProgress', {
+									current: match.current,
+									total: match.total,
+								})}
+							</Typography>
+						</Box>
+					</Stack>
+				</Stack>
+				<LeaderBoard />
+				<Box sx={styles.players}>
+					{match.data.players.map((player) => (
+						<Player key={player.id} player={player} onRename={() => {}} readOnly />
+					))}
+				</Box>
+			</PlayingLayout>
+		);
+	}
+
+	return (
+		<Box sx={styles.listWrapper}>
+			<Stack
+				sx={styles.listHeader}
+				direction="row"
+				alignItems="center"
+				justifyContent="space-between"
+			>
+				<Typography sx={styles.listTitle}>{t('pages.dashboard.title')}</Typography>
+				<IconButton color="primary" onClick={logout} aria-label={t('pages.dashboard.logout')}>
+					<LogoutIcon />
+				</IconButton>
+			</Stack>
+			{isLoadingList ? (
+				<Box sx={styles.stateWrapper}>
+					<CircularProgress />
+				</Box>
+			) : matches.length === 0 ? (
+				<Typography>{t('pages.dashboard.empty')}</Typography>
+			) : (
+				<Table size="small">
+					<TableHead>
+						<TableRow>
+							<TableCell>{t('pages.dashboard.table.name')}</TableCell>
+							<TableCell>{t('pages.dashboard.table.status')}</TableCell>
+							<TableCell align="right">{t('pages.dashboard.table.rounds')}</TableCell>
+							<TableCell align="right">{t('pages.dashboard.table.players')}</TableCell>
+							<TableCell>{t('pages.dashboard.table.createdAt')}</TableCell>
+						</TableRow>
+					</TableHead>
+					<TableBody>
+						{matches.map((item) => (
+							<TableRow key={item.id} hover sx={styles.row} onClick={() => openMatch(item.id)}>
+								<TableCell>{item.name}</TableCell>
+								<TableCell>
+									<Chip
+										size="small"
+										color={item.isFinished ? 'default' : 'primary'}
+										label={
+											item.isFinished
+												? t('pages.dashboard.status.finished')
+												: t('pages.dashboard.status.playing')
+										}
+									/>
+								</TableCell>
+								<TableCell align="right">{item.total}</TableCell>
+								<TableCell align="right">{item.playerCount}</TableCell>
+								<TableCell>{dayjs(item.createdAt).format('DD/MM/YYYY HH:mm')}</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			)}
+		</Box>
+	);
+}
+
+export default DashboardPage;

--- a/src/pages/DashboardPage/hooks/index.ts
+++ b/src/pages/DashboardPage/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useDashboard } from './useDashboard';

--- a/src/pages/DashboardPage/hooks/useDashboard.ts
+++ b/src/pages/DashboardPage/hooks/useDashboard.ts
@@ -1,0 +1,108 @@
+import {
+	ADMIN_TOKEN_KEY,
+	AdminAuthError,
+	AdminMatchSummary,
+	adminGetMatch,
+	adminGetMatches,
+	adminLogin,
+} from '@/api';
+import { useAppDispatch } from '@/redux/hooks';
+import { updateIsShowResult, updateMatchDetail } from '@/redux/slices/matchSlice';
+import { translateError } from '@/utils/helpers';
+import { useCallback, useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+
+type View = 'login' | 'list' | 'detail';
+
+function useDashboard() {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+	const [token, setToken] = useState<string | null>(() => localStorage.getItem(ADMIN_TOKEN_KEY));
+	const [username, setUsername] = useState('');
+	const [password, setPassword] = useState('');
+	const [matches, setMatches] = useState<AdminMatchSummary[]>([]);
+	const [selectedId, setSelectedId] = useState<number | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [isLoadingList, setIsLoadingList] = useState(false);
+	const [isLoadingDetail, setIsLoadingDetail] = useState(false);
+
+	const view: View = !token ? 'login' : selectedId ? 'detail' : 'list';
+
+	const clearSession = useCallback(() => {
+		localStorage.removeItem(ADMIN_TOKEN_KEY);
+		setToken(null);
+		setMatches([]);
+		setSelectedId(null);
+	}, []);
+
+	const loadMatches = useCallback(() => {
+		setIsLoadingList(true);
+		adminGetMatches()
+			.then(setMatches)
+			.catch((error) => {
+				if (error instanceof AdminAuthError) clearSession();
+				toast.error(translateError(error, t));
+			})
+			.finally(() => setIsLoadingList(false));
+	}, [clearSession, t]);
+
+	useEffect(() => {
+		if (token) loadMatches();
+	}, [token, loadMatches]);
+
+	const login = () => {
+		setIsSubmitting(true);
+		adminLogin(username, password)
+			.then((newToken) => {
+				localStorage.setItem(ADMIN_TOKEN_KEY, newToken);
+				setPassword('');
+				setToken(newToken);
+			})
+			.catch((error) => toast.error(translateError(error, t)))
+			.finally(() => setIsSubmitting(false));
+	};
+
+	const logout = () => clearSession();
+
+	const openMatch = (id: number) => {
+		setIsLoadingDetail(true);
+		adminGetMatch(id)
+			.then((detail) => {
+				dispatch(
+					updateMatchDetail({
+						current: detail.total,
+						total: detail.total,
+						data: detail,
+					}),
+				);
+				dispatch(updateIsShowResult(!!detail.isFinished));
+				setSelectedId(id);
+			})
+			.catch((error) => {
+				if (error instanceof AdminAuthError) clearSession();
+				toast.error(translateError(error, t));
+			})
+			.finally(() => setIsLoadingDetail(false));
+	};
+
+	const backToList = () => setSelectedId(null);
+
+	return {
+		view,
+		username,
+		password,
+		matches,
+		isSubmitting,
+		isLoadingList,
+		isLoadingDetail,
+		setUsername,
+		setPassword,
+		login,
+		logout,
+		openMatch,
+		backToList,
+	};
+}
+
+export default useDashboard;

--- a/src/pages/DashboardPage/index.ts
+++ b/src/pages/DashboardPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './DashboardPage';

--- a/src/pages/DashboardPage/styles.ts
+++ b/src/pages/DashboardPage/styles.ts
@@ -1,0 +1,75 @@
+import { SxProps, Theme, alpha } from '@mui/material';
+
+const styles: Record<string, SxProps<Theme>> = {
+	stateWrapper: {
+		display: 'flex',
+		flexDirection: 'column',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '12px',
+		minHeight: '60vh',
+	},
+	loginWrapper: {
+		display: 'flex',
+		flexDirection: 'column',
+		gap: '16px',
+		maxWidth: '360px',
+		margin: '0 auto',
+		padding: '48px 1rem',
+	},
+	loginTitle: {
+		fontSize: '20px',
+		fontWeight: 'bold',
+		textAlign: 'center',
+	},
+	listWrapper: {
+		padding: '16px 1rem',
+	},
+	listHeader: {
+		marginBottom: '12px',
+	},
+	listTitle: {
+		fontSize: '18px',
+		fontWeight: 'bold',
+	},
+	row: {
+		cursor: 'pointer',
+	},
+	header: (theme: Theme) => ({
+		position: 'sticky',
+		top: 0,
+		zIndex: 2,
+		padding: '12px 1rem',
+		backgroundColor: theme.palette.background.paper,
+		borderBottom: `1px solid ${theme.palette.divider}`,
+	}),
+	matchTitle: {
+		fontSize: '16px',
+		fontWeight: 'bold',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap',
+	},
+	roundPill: (theme: Theme) => ({
+		display: 'inline-flex',
+		alignItems: 'center',
+		alignSelf: 'flex-start',
+		padding: '2px 10px',
+		borderRadius: '999px',
+		backgroundColor: alpha(theme.palette.primary.main, 0.12),
+		color: theme.palette.primary.main,
+	}),
+	roundPillText: {
+		fontSize: '13px',
+		fontWeight: 'bold',
+		lineHeight: 1.4,
+	},
+	players: {
+		display: 'flex',
+		flexDirection: 'column',
+		padding: '12px 1rem',
+		gap: '8px',
+	},
+};
+
+export default styles;

--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -1,8 +1,11 @@
+import { useAppDispatch } from '@/redux/hooks';
+import { fetchMatches } from '@/redux/slices/matchSlice';
 import { ROUTES } from '@/routes/constants';
 import AddIcon from '@mui/icons-material/Add';
 import ArrowRightIcon from '@mui/icons-material/ArrowRight';
 import Button from '@mui/material/Button';
 import Stack from '@mui/material/Stack';
+import { useEffect } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
 import { Banner, ListingMatchesDialog, Title } from './components';
@@ -11,6 +14,11 @@ import { styles } from './utils';
 function HomePage() {
 	const { t } = useTranslation();
 	const navigate = useNavigate();
+	const dispatch = useAppDispatch();
+
+	useEffect(() => {
+		dispatch(fetchMatches());
+	}, [dispatch]);
 
 	const handleStartNewGameClick = () => {
 		navigate(ROUTES.CREATE_NEW_MATCH);

--- a/src/pages/HomePage/components/ListingMatchesDialog/ListingMatchesDialog.tsx
+++ b/src/pages/HomePage/components/ListingMatchesDialog/ListingMatchesDialog.tsx
@@ -36,8 +36,11 @@ function ListingMatchesDialog({ children }: Props) {
 		onClose,
 		inProgressMatches,
 		finishedMatches,
+		sharedMatches,
 		onItemClick,
 		onDeleteItem,
+		onSharedItemClick,
+		onDeleteSharedItem,
 		confirmActionRef,
 	} = useListingMatchesDialog();
 
@@ -69,6 +72,41 @@ function ListingMatchesDialog({ children }: Props) {
 							<Typography sx={styles.empty}>
 								<SentimentVeryDissatisfiedIcon color="action" />
 								{t('components.listingMatches.noFinished')}
+							</Typography>
+						)}
+						<Divider variant="middle" />
+						<ListSubheader>{t('components.listingMatches.shared')}</ListSubheader>
+						{sharedMatches.map((entry) => (
+							<ListItem
+								disablePadding
+								key={entry.token}
+								secondaryAction={
+									<IconButton
+										edge="end"
+										aria-label="delete"
+										onClick={() => onDeleteSharedItem(entry.token)}
+									>
+										<DeleteIcon />
+									</IconButton>
+								}
+							>
+								<ListItemButton onClick={() => onSharedItemClick(entry.token)}>
+									<ListItemAvatar>
+										<Avatar sx={{ backgroundColor: helpers.stringToColor(entry.name) }}>
+											{helpers.getShortName(entry.name)}
+										</Avatar>
+									</ListItemAvatar>
+									<ListItemText
+										primary={entry.name}
+										secondary={dayjs(entry.viewedAt).format(DATE_FORMAT)}
+									/>
+								</ListItemButton>
+							</ListItem>
+						))}
+						{sharedMatches.length === 0 && (
+							<Typography sx={styles.empty}>
+								<SentimentVeryDissatisfiedIcon color="action" />
+								{t('components.listingMatches.noShared')}
 							</Typography>
 						)}
 					</List>
@@ -109,7 +147,7 @@ const Item = ({
 					{helpers.getShortName(match.name)}
 				</Avatar>
 			</ListItemAvatar>
-			<ListItemText primary={match.name} secondary={dayjs(match.id).format(DATE_FORMAT)} />
+			<ListItemText primary={match.name} secondary={dayjs(match.createdAt).format(DATE_FORMAT)} />
 		</ListItemButton>
 	</ListItem>
 );

--- a/src/pages/HomePage/components/ListingMatchesDialog/useListingMatchesDialog.ts
+++ b/src/pages/HomePage/components/ListingMatchesDialog/useListingMatchesDialog.ts
@@ -1,19 +1,26 @@
 import type { ConfirmModalRef } from '@/components/ConfirmModal/ConfirmModal';
 import { useBoolean } from '@/hooks';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
-import { updateMatches } from '@/redux/slices/matchSlice';
+import { fetchMatches } from '@/redux/slices/matchSlice';
 import { RootState } from '@/redux/store';
 import { ROUTES } from '@/routes/constants';
 import { matchService } from '@/services';
-import { useRef } from 'react';
+import { getSharedHistory, removeSharedHistory } from '@/utils/helpers';
+import { useRef, useState } from 'react';
 import { generatePath, useNavigate } from 'react-router-dom';
 
 function useListingMatchesDialog() {
-	const { value: isOpen, setTrue: onOpen, setFalse: onClose } = useBoolean(false);
+	const { value: isOpen, setTrue: openDialog, setFalse: onClose } = useBoolean(false);
 	const confirmActionRef = useRef<ConfirmModalRef>(null);
 	const matches = useAppSelector((state: RootState) => state.match.matches);
+	const [sharedMatches, setSharedMatches] = useState(getSharedHistory);
 	const dispatch = useAppDispatch();
 	const navigate = useNavigate();
+
+	const onOpen = () => {
+		setSharedMatches(getSharedHistory());
+		openDialog();
+	};
 
 	const onItemClick = (id: number) => {
 		onClose();
@@ -21,11 +28,19 @@ function useListingMatchesDialog() {
 		navigate(path);
 	};
 
+	const onSharedItemClick = (token: string) => {
+		onClose();
+		navigate(generatePath(ROUTES.SHARE, { token }));
+	};
+
+	const onDeleteSharedItem = (token: string) => {
+		setSharedMatches(removeSharedHistory(token));
+	};
+
 	const onDeleteItem = (id: number) => {
-		confirmActionRef.current?.confirm(() => {
-			matchService.delete(id);
-			const newMatch = matchService.getAll();
-			dispatch(updateMatches(newMatch));
+		confirmActionRef.current?.confirm(async () => {
+			await matchService.delete(id);
+			dispatch(fetchMatches());
 		});
 	};
 
@@ -40,8 +55,11 @@ function useListingMatchesDialog() {
 		matches,
 		finishedMatches,
 		inProgressMatches,
+		sharedMatches,
 		onItemClick,
 		onDeleteItem,
+		onSharedItemClick,
+		onDeleteSharedItem,
 		confirmActionRef,
 	};
 }

--- a/src/pages/PlayingPage/components/DragDropPlayer/DragDropPlayer.tsx
+++ b/src/pages/PlayingPage/components/DragDropPlayer/DragDropPlayer.tsx
@@ -47,7 +47,7 @@ function DragDropPlayer({ children, isAllow }: DragDropPlayerProps) {
 										{...provider.draggableProps}
 										style={getDragItemStyle(provider.draggableProps.style as CSSProperties)}
 									>
-										{children(player, provider.dragHandleProps, isAllow)}
+										{children(player, provider.dragHandleProps ?? undefined, isAllow)}
 									</div>
 								)}
 							</Draggable>

--- a/src/pages/PlayingPage/components/Hero/Hero.tsx
+++ b/src/pages/PlayingPage/components/Hero/Hero.tsx
@@ -13,7 +13,7 @@ import styles from './styles';
 import DragDropPlayer from '../DragDropPlayer';
 
 function Hero() {
-	const { isEmptyPlayer, isFinished, match, onAdjustPlayer, onUpdatePlayerAvatar } = usePlaying();
+	const { isEmptyPlayer, isFinished, match, onAdjustPlayer } = usePlaying();
 	const playerModifierDialogRef = useRef<PlayerModifierDialogRefType>(null);
 
 	const onRenamePlayer = (player: PlayerType) => {
@@ -41,11 +41,7 @@ function Hero() {
 						)}
 					</DragDropPlayer>
 					{isAllowedActionForPlayer && (
-						<PlayerModifierDialog
-							ref={playerModifierDialogRef}
-							onSubmit={onAdjustPlayer}
-							onAvatarChange={onUpdatePlayerAvatar}
-						>
+						<PlayerModifierDialog ref={playerModifierDialogRef} onSubmit={onAdjustPlayer}>
 							<Button variant="contained" size="small" startIcon={<AddIcon />} />
 						</PlayerModifierDialog>
 					)}

--- a/src/pages/PlayingPage/components/Player/Player.tsx
+++ b/src/pages/PlayingPage/components/Player/Player.tsx
@@ -31,9 +31,10 @@ type Props = {
 	onRename: (player: PlayerType) => void;
 	dragHandleProps?: DraggableProvidedDragHandleProps;
 	isDragEnabled?: boolean;
+	readOnly?: boolean;
 };
 
-function Player({ player, onRename, dragHandleProps, isDragEnabled }: Props) {
+function Player({ player, onRename, dragHandleProps, isDragEnabled, readOnly }: Props) {
 	const { t } = useTranslation();
 	const setting = useAppSelector((state: RootState) => state.setting);
 	const { match, onScorePlayerChange, onToggleAutoFill, onUpdatePlayerGap } = usePlaying();
@@ -46,8 +47,8 @@ function Player({ player, onRename, dragHandleProps, isDragEnabled }: Props) {
 	const currentValue = player.scores[currentGameNumber - 1] || 0;
 	const effectiveGap = player.gap ?? setting.gap;
 	const hasCustomGap = player.gap !== undefined;
-	const showDragHandle = isDragEnabled && setting.uiMode === 'full';
-	const nameIsDragHandle = !!isDragEnabled && setting.uiMode === 'compact';
+	const showDragHandle = !readOnly && isDragEnabled && setting.uiMode === 'full';
+	const nameIsDragHandle = !readOnly && !!isDragEnabled && setting.uiMode === 'compact';
 
 	const [gapAnchorEl, setGapAnchorEl] = useState<HTMLElement | null>(null);
 	const [gapDisplayValue, setGapDisplayValue] = useState<string>(effectiveGap.toString());
@@ -89,7 +90,7 @@ function Player({ player, onRename, dragHandleProps, isDragEnabled }: Props) {
 					direction="row"
 					alignItems="center"
 					gap="6px"
-					onClick={() => onRename(player)}
+					onClick={() => !readOnly && onRename(player)}
 					sx={styles.nameRow(nameIsDragHandle)}
 					{...(nameIsDragHandle && dragHandleProps ? dragHandleProps : {})}
 				>
@@ -114,15 +115,19 @@ function Player({ player, onRename, dragHandleProps, isDragEnabled }: Props) {
 						</Stack>
 					</Stack>
 					<Stack sx={styles.scoreCell} alignItems="flex-end">
-						<InputScore
-							disabled={isFinished || !!player.autoFill}
-							value={currentValue}
-							onChange={handleScoreChange}
-							gap={effectiveGap}
-						/>
+						{readOnly ? (
+							<Typography sx={styles.totalValue(currentValue)}>{currentValue}</Typography>
+						) : (
+							<InputScore
+								disabled={isFinished || !!player.autoFill}
+								value={currentValue}
+								onChange={handleScoreChange}
+								gap={effectiveGap}
+							/>
+						)}
 					</Stack>
 				</Box>
-				{!isFinished && (
+				{!isFinished && !readOnly && (
 					<Box sx={styles.scoreGrid}>
 						<Stack sx={styles.scoreCell} alignItems="flex-start">
 							<Stack

--- a/src/pages/PlayingPage/components/PlayingActionBar/PlayingActionBar.tsx
+++ b/src/pages/PlayingPage/components/PlayingActionBar/PlayingActionBar.tsx
@@ -1,11 +1,14 @@
 import {
 	ArrowForward as ArrowForwardIcon,
 	Leaderboard as LeaderboardIcon,
+	Share as ShareIcon,
 } from '@mui/icons-material';
-import { Box, Button, Typography } from '@mui/material';
+import { Box, Button, Stack, Typography } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import type { ConfirmOptions } from '@/components/ConfirmModal/ConfirmModal';
+import { useBoolean } from '@/hooks';
 import { usePlaying } from '../../hooks';
+import ShareLinkDialog from '../ShareLinkDialog';
 import styles from './styles';
 
 type Props = {
@@ -15,29 +18,12 @@ type Props = {
 function PlayingActionBar({ onConfirm }: Props) {
 	const { t } = useTranslation();
 	const { match, onPlayContinue, toggleShowResult } = usePlaying();
+	const { value: isShareOpen, setTrue: openShare, setFalse: closeShare } = useBoolean(false);
 	const currentGame = match?.current;
 	const totalGame = match?.total;
+	const matchId = match?.data.id;
 	const isFinished = match?.data.isFinished;
 	const isLastGame = currentGame === totalGame;
-
-	if (isFinished) {
-		return (
-			<Box sx={styles.wrapper}>
-				<Button
-					fullWidth
-					variant="contained"
-					size="large"
-					startIcon={<LeaderboardIcon />}
-					onClick={toggleShowResult}
-					sx={styles.primaryButton}
-				>
-					<Typography sx={styles.primaryLabel}>{t('pages.playing.leaderboard')}</Typography>
-				</Button>
-			</Box>
-		);
-	}
-
-	if (!isLastGame) return null;
 
 	const handleNextRound = () =>
 		onConfirm(onPlayContinue, {
@@ -46,18 +32,45 @@ function PlayingActionBar({ onConfirm }: Props) {
 			bodyParams: { current: currentGame },
 		});
 
+	const primaryButton = isFinished ? (
+		<Button
+			fullWidth
+			variant="contained"
+			size="large"
+			startIcon={<LeaderboardIcon />}
+			onClick={toggleShowResult}
+			sx={styles.primaryButton}
+		>
+			<Typography sx={styles.primaryLabel}>{t('pages.playing.leaderboard')}</Typography>
+		</Button>
+	) : isLastGame ? (
+		<Button
+			fullWidth
+			variant="contained"
+			size="large"
+			endIcon={<ArrowForwardIcon />}
+			onClick={handleNextRound}
+			sx={styles.primaryButton}
+		>
+			<Typography sx={styles.primaryLabel}>{t('pages.playing.nextRound')}</Typography>
+		</Button>
+	) : null;
+
 	return (
 		<Box sx={styles.wrapper}>
-			<Button
-				fullWidth
-				variant="contained"
-				size="large"
-				endIcon={<ArrowForwardIcon />}
-				onClick={handleNextRound}
-				sx={styles.primaryButton}
-			>
-				<Typography sx={styles.primaryLabel}>{t('pages.playing.nextRound')}</Typography>
-			</Button>
+			<Stack gap="8px">
+				{primaryButton}
+				<Button
+					fullWidth
+					variant="outlined"
+					size="large"
+					startIcon={<ShareIcon />}
+					onClick={openShare}
+				>
+					{t('components.shareLink.action')}
+				</Button>
+			</Stack>
+			<ShareLinkDialog isOpen={isShareOpen} onClose={closeShare} matchId={matchId} />
 		</Box>
 	);
 }

--- a/src/pages/PlayingPage/components/ShareLinkDialog/ShareLinkDialog.tsx
+++ b/src/pages/PlayingPage/components/ShareLinkDialog/ShareLinkDialog.tsx
@@ -1,0 +1,78 @@
+import { Dialog } from '@/components';
+import { matchService } from '@/services';
+import { translateError } from '@/utils/helpers';
+import { ContentCopy as ContentCopyIcon } from '@mui/icons-material';
+import { Box, Button, CircularProgress, TextField, Typography } from '@mui/material';
+import { useEffect, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'react-toastify';
+import styles from './styles';
+
+type Props = {
+	isOpen: boolean;
+	onClose: () => void;
+	matchId?: number;
+};
+
+function ShareLinkDialog({ isOpen, onClose, matchId }: Props) {
+	const { t } = useTranslation();
+	const [token, setToken] = useState<string>();
+	const [isLoading, setIsLoading] = useState(false);
+	const [isCopied, setIsCopied] = useState(false);
+
+	useEffect(() => {
+		if (!isOpen || !matchId || token) return;
+
+		setIsLoading(true);
+		matchService
+			.share(matchId)
+			.then((result) => setToken(result.token))
+			.catch((error) => toast.error(translateError(error, t)))
+			.finally(() => setIsLoading(false));
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [isOpen, matchId]);
+
+	const shareUrl = token ? `${window.location.origin}/share/${token}` : '';
+
+	const handleCopy = async () => {
+		if (!shareUrl) return;
+		await navigator.clipboard.writeText(shareUrl);
+		setIsCopied(true);
+		setTimeout(() => setIsCopied(false), 2000);
+	};
+
+	return (
+		<Dialog isOpen={isOpen} onClose={onClose}>
+			<Dialog.DialogTitle>{t('components.shareLink.title')}</Dialog.DialogTitle>
+			<Dialog.DialogContent sx={styles.content}>
+				<Typography sx={styles.description}>{t('components.shareLink.description')}</Typography>
+				{isLoading ? (
+					<Box sx={styles.loading}>
+						<CircularProgress size={24} />
+					</Box>
+				) : (
+					<TextField
+						value={shareUrl}
+						InputProps={{ readOnly: true }}
+						size="small"
+						fullWidth
+						onFocus={(e) => e.target.select()}
+					/>
+				)}
+			</Dialog.DialogContent>
+			<Dialog.DialogActions>
+				<Button onClick={onClose}>{t('components.shareLink.close')}</Button>
+				<Button
+					variant="contained"
+					startIcon={<ContentCopyIcon />}
+					onClick={handleCopy}
+					disabled={!token}
+				>
+					{isCopied ? t('components.shareLink.copied') : t('components.shareLink.copy')}
+				</Button>
+			</Dialog.DialogActions>
+		</Dialog>
+	);
+}
+
+export default ShareLinkDialog;

--- a/src/pages/PlayingPage/components/ShareLinkDialog/index.ts
+++ b/src/pages/PlayingPage/components/ShareLinkDialog/index.ts
@@ -1,0 +1,1 @@
+export { default } from './ShareLinkDialog';

--- a/src/pages/PlayingPage/components/ShareLinkDialog/styles.ts
+++ b/src/pages/PlayingPage/components/ShareLinkDialog/styles.ts
@@ -1,0 +1,21 @@
+import { SxProps, Theme } from '@mui/material';
+
+const styles: Record<string, SxProps<Theme>> = {
+	content: {
+		display: 'flex',
+		flexDirection: 'column',
+		gap: '12px',
+		minWidth: '260px',
+	},
+	description: {
+		fontSize: '14px',
+		color: 'text.secondary',
+	},
+	loading: {
+		display: 'flex',
+		justifyContent: 'center',
+		py: '16px',
+	},
+};
+
+export default styles;

--- a/src/pages/PlayingPage/components/index.ts
+++ b/src/pages/PlayingPage/components/index.ts
@@ -3,3 +3,4 @@ export { default as PlayingHeader } from './PlayingHeader';
 export { default as PlayingActionBar } from './PlayingActionBar';
 export { default as Hero } from './Hero';
 export { default as Player } from './Player';
+export { default as LeaderBoard } from './LeaderBoard';

--- a/src/pages/PlayingPage/hooks/useDraggablePlayer.ts
+++ b/src/pages/PlayingPage/hooks/useDraggablePlayer.ts
@@ -16,7 +16,7 @@ function useDraggablePlayer() {
 	const matchId = match?.data.id as number;
 	const players = match?.data.players ?? [];
 
-	const onDragEnd: OnDragEndResponder = (result, provided) => {
+	const onDragEnd: OnDragEndResponder = async (result) => {
 		try {
 			if (!match) {
 				throw new Error(t('errors.match.notFound'));
@@ -36,9 +36,7 @@ function useDraggablePlayer() {
 			clonePlayers.splice(result.source.index, 1);
 			clonePlayers.splice(result.destination.index, 0, sourcePlayer);
 
-			matchService.updatePositionOfPlayer(matchId, clonePlayers);
-
-			const newMatch = matchService.get(matchId);
+			const newMatch = await matchService.updatePositionOfPlayer(matchId, clonePlayers);
 			dispatch(updateMatchDetailData(newMatch));
 			toast.success(t('toast.positionChanged'));
 		} catch (error) {

--- a/src/pages/PlayingPage/hooks/usePlaying.ts
+++ b/src/pages/PlayingPage/hooks/usePlaying.ts
@@ -1,19 +1,23 @@
 import { useAddQueryParams } from '@/hooks';
 import { useAppDispatch, useAppSelector } from '@/redux/hooks';
 import {
+	fetchMatches,
 	updateCurrentGame,
 	updateIsShowResult,
 	updateMatchDetail,
 	updateMatchDetailData,
-	updateMatches,
+	updatePlayerScore,
 } from '@/redux/slices/matchSlice';
 import { RootState } from '@/redux/store';
 import { matchService } from '@/services';
 import { translateError, scrollToTop } from '@/utils/helpers';
 import { PlayerLeaderBoard } from '@/utils/types';
+import { validateSingleGameScore } from '@/utils/validators/matchValidator';
 import { toast } from 'react-toastify';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const SCORE_DEBOUNCE_MS = 400;
 
 /**
  * Custom hook for managing playing page state and operations
@@ -26,6 +30,20 @@ function usePlaying() {
 	const isShowResult = match?.isShowResult ?? false;
 	const { updateQueryParams } = useAddQueryParams();
 	const { t } = useTranslation();
+
+	/**
+	 * One debounce timer per (playerId, gameIndex) score cell so edits to
+	 * different cells within the debounce window are not coalesced together.
+	 */
+	const scoreTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+
+	useEffect(() => {
+		const timers = scoreTimers.current;
+		return () => {
+			timers.forEach((timer) => clearTimeout(timer));
+			timers.clear();
+		};
+	}, []);
 
 	/**
 	 * Memoize players to ensure stable reference and prevent unnecessary recalculations
@@ -51,18 +69,6 @@ function usePlaying() {
 	);
 
 	/**
-	 * Refreshes match data from service and updates Redux state
-	 */
-	const refreshMatchData = (): void => {
-		try {
-			const updatedMatch = matchService.get(matchId);
-			dispatch(updateMatchDetailData(updatedMatch));
-		} catch (error) {
-			toast.error(translateError(error, t));
-		}
-	};
-
-	/**
 	 * Moves to the last game in the match
 	 */
 	const moveToEnd = (): void => {
@@ -81,7 +87,7 @@ function usePlaying() {
 		try {
 			if (!match) return;
 
-			matchService.validateGameNumber(matchId, match.current);
+			validateSingleGameScore(match.data, match.current);
 			dispatch(updateCurrentGame(gameNumber));
 			updateQueryParams({ gN: gameNumber.toString() });
 		} catch (error) {
@@ -92,10 +98,10 @@ function usePlaying() {
 	/**
 	 * Advances to the next game
 	 */
-	const onPlayContinue = (): void => {
+	const onPlayContinue = async (): Promise<void> => {
 		try {
-			const newMatch = matchService.nextGame(matchId);
-			const nextGameNumber = match?.total ? match?.total + 1 : 1;
+			const newMatch = await matchService.nextGame(matchId);
+			const nextGameNumber = newMatch.players.find(Boolean)?.scores.length || 1;
 			const payload = {
 				current: nextGameNumber,
 				total: nextGameNumber,
@@ -113,15 +119,12 @@ function usePlaying() {
 	/**
 	 * Finishes the match and shows results
 	 */
-	const onFinish = (): void => {
+	const onFinish = async (): Promise<void> => {
 		try {
-			const finishedMatch = matchService.endGame(matchId);
+			const finishedMatch = await matchService.endGame(matchId);
 			dispatch(updateMatchDetailData(finishedMatch));
 			toggleShowResult();
-
-			// Refresh matches list to reflect finished status
-			const allMatches = matchService.getAll();
-			dispatch(updateMatches(allMatches));
+			dispatch(fetchMatches());
 		} catch (error) {
 			toast.error(translateError(error, t));
 		} finally {
@@ -130,49 +133,76 @@ function usePlaying() {
 	};
 
 	/**
-	 * Adds a new player or updates existing player name
+	 * Adds a new player or updates existing player name (and avatar, if changed)
 	 * @param name - Player name
 	 * @param id - Player ID (if editing existing player)
+	 * @param avatar - Base64 string, null to remove, undefined to keep unchanged
 	 */
-	const onAdjustPlayer = (name: string, id?: number): void => {
+	const onAdjustPlayer = async (
+		name: string,
+		id?: number,
+		avatar?: string | null,
+	): Promise<void> => {
 		try {
-			const isEdit = !!id;
-
-			if (isEdit) {
-				matchService.updatePlayerName(matchId, id, name);
-			} else {
-				matchService.addPlayer(matchId, name);
-			}
-
-			refreshMatchData();
+			const updatedMatch = id
+				? await matchService.updatePlayerName(matchId, id, name, avatar)
+				: await matchService.addPlayer(matchId, name);
+			dispatch(updateMatchDetailData(updatedMatch));
 		} catch (error) {
 			toast.error(translateError(error, t));
 		}
 	};
 
 	/**
-	 * Updates a player's score for a specific game
+	 * Updates a player's score for a specific game.
+	 * Optimistic: redux updates instantly, the API write runs debounced in the
+	 * background and its snapshot reconciles server-side effects (autoFill).
 	 * @param playerId - Player ID
 	 * @param gameNumber - Game number (1-indexed)
 	 * @param score - New score value
 	 */
 	const onScorePlayerChange = (playerId: number, gameNumber: number, score: number): void => {
-		try {
-			matchService.updateScoreOfPlayer(matchId, playerId, gameNumber, score);
-			refreshMatchData();
-		} catch (error) {
-			toast.error(translateError(error, t));
-		}
+		dispatch(updatePlayerScore({ playerId, gameIndex: gameNumber - 1, value: score }));
+
+		const key = `${playerId}-${gameNumber}`;
+		const timers = scoreTimers.current;
+
+		const existingTimer = timers.get(key);
+		if (existingTimer) clearTimeout(existingTimer);
+
+		const timer = setTimeout(async () => {
+			timers.delete(key);
+			try {
+				const updatedMatch = await matchService.updateScoreOfPlayer(
+					matchId,
+					playerId,
+					gameNumber,
+					score,
+				);
+				// Skip reconciling while other cells still have pending writes,
+				// otherwise this snapshot would clobber their optimistic values.
+				if (timers.size === 0) dispatch(updateMatchDetailData(updatedMatch));
+			} catch (error) {
+				toast.error(translateError(error, t));
+				// Resync so the optimistic value does not silently diverge.
+				try {
+					dispatch(updateMatchDetailData(await matchService.get(matchId)));
+				} catch {
+					// Keep the optimistic state; next successful call resyncs.
+				}
+			}
+		}, SCORE_DEBOUNCE_MS);
+
+		timers.set(key, timer);
 	};
 
 	/**
 	 * Toggles autoFill for a player (only one at a time)
 	 * @param playerId - Player ID
 	 */
-	const onToggleAutoFill = (playerId: number): void => {
+	const onToggleAutoFill = async (playerId: number): Promise<void> => {
 		try {
-			const currentGameNumber = match?.current ?? 1;
-			const updatedMatch = matchService.togglePlayerAutoFill(matchId, playerId, currentGameNumber);
+			const updatedMatch = await matchService.togglePlayerAutoFill(matchId, playerId);
 			dispatch(updateMatchDetailData(updatedMatch));
 		} catch (error) {
 			toast.error(translateError(error, t));
@@ -184,24 +214,10 @@ function usePlaying() {
 	 * @param playerId - Player ID
 	 * @param gap - New gap value (undefined to reset to global)
 	 */
-	const onUpdatePlayerGap = (playerId: number, gap?: number): void => {
+	const onUpdatePlayerGap = async (playerId: number, gap?: number): Promise<void> => {
 		try {
-			matchService.updatePlayerGap(matchId, playerId, gap);
-			refreshMatchData();
-		} catch (error) {
-			toast.error(translateError(error, t));
-		}
-	};
-
-	/**
-	 * Updates a player's avatar
-	 * @param playerId - Player ID
-	 * @param avatar - Base64 image string (undefined to remove)
-	 */
-	const onUpdatePlayerAvatar = (playerId: number, avatar?: string): void => {
-		try {
-			matchService.updatePlayerAvatar(matchId, playerId, avatar);
-			refreshMatchData();
+			const updatedMatch = await matchService.updatePlayerGap(matchId, playerId, gap);
+			dispatch(updateMatchDetailData(updatedMatch));
 		} catch (error) {
 			toast.error(translateError(error, t));
 		}
@@ -225,7 +241,6 @@ function usePlaying() {
 		onScorePlayerChange,
 		onToggleAutoFill,
 		onUpdatePlayerGap,
-		onUpdatePlayerAvatar,
 		moveToEnd,
 		onShowGameNumber,
 		onPlayContinue,

--- a/src/pages/PlayingPage/hooks/usePlayingFetcher.ts
+++ b/src/pages/PlayingPage/hooks/usePlayingFetcher.ts
@@ -16,12 +16,12 @@ function usePlayingFetcher() {
 	const { params } = useAddQueryParams();
 	const { t } = useTranslation();
 
-	const fetchMatch = useCallback(() => {
+	const fetchMatch = useCallback(async () => {
 		try {
 			if (!id) throw new Error('errors.match.notFound');
 
-			const newMatch = matchService.get(+id);
-			const totalGameNumber = matchService.getCurrentGameNumber(+id);
+			const newMatch = await matchService.get(+id);
+			const totalGameNumber = newMatch.players.find(Boolean)?.scores.length || 1;
 			const gameNumberParam = params.get('gN');
 			const current = gameNumberParam ? +gameNumberParam : totalGameNumber;
 			const payload = {

--- a/src/pages/SharedViewPage/SharedViewPage.tsx
+++ b/src/pages/SharedViewPage/SharedViewPage.tsx
@@ -1,0 +1,104 @@
+import { useAppDispatch } from '@/redux/hooks';
+import { updateCurrentGame } from '@/redux/slices/matchSlice';
+import {
+	KeyboardArrowLeft as KeyboardArrowLeftIcon,
+	KeyboardArrowRight as KeyboardArrowRightIcon,
+	KeyboardDoubleArrowRight as KeyboardDoubleArrowRightIcon,
+	Leaderboard as LeaderboardIcon,
+} from '@mui/icons-material';
+import { Box, CircularProgress, IconButton, Stack, Typography } from '@mui/material';
+import { useTranslation } from 'react-i18next';
+import { LeaderBoard, Player, PlayingLayout } from '../PlayingPage/components';
+import { usePlaying } from '../PlayingPage/hooks';
+import { useSharedView } from './hooks';
+import styles from './styles';
+
+function SharedViewPage() {
+	const { t } = useTranslation();
+	const dispatch = useAppDispatch();
+	const { isLoading, hasError } = useSharedView();
+	const { match, toggleShowResult } = usePlaying();
+
+	const onChangeGame = (gameNumber: number) => () => {
+		dispatch(updateCurrentGame(gameNumber));
+	};
+
+	if (isLoading) {
+		return (
+			<Box sx={styles.stateWrapper}>
+				<CircularProgress />
+			</Box>
+		);
+	}
+
+	if (hasError || !match) {
+		return (
+			<Box sx={styles.stateWrapper}>
+				<Typography>{t('pages.shared.notFound')}</Typography>
+			</Box>
+		);
+	}
+
+	const players = match.data.players;
+
+	return (
+		<PlayingLayout>
+			<Stack
+				sx={styles.header}
+				direction="row"
+				alignItems="center"
+				justifyContent="space-between"
+				gap="12px"
+			>
+				<Stack sx={{ minWidth: 0 }}>
+					<Typography sx={styles.matchTitle}>
+						{t('pages.playing.matchLabel', { name: match.data.name })}
+					</Typography>
+					<Stack direction="row" alignItems="center" gap="2px">
+						{match.current > 1 && (
+							<IconButton sx={styles.p0} onClick={onChangeGame(match.current - 1)}>
+								<KeyboardArrowLeftIcon color="primary" />
+							</IconButton>
+						)}
+						<Box sx={styles.roundPill}>
+							<Typography sx={styles.roundPillText}>
+								{t('pages.playing.roundProgress', {
+									current: match.current,
+									total: match.total,
+								})}
+							</Typography>
+						</Box>
+						{match.current < match.total && (
+							<IconButton sx={styles.p0} onClick={onChangeGame(match.current + 1)}>
+								<KeyboardArrowRightIcon color="primary" />
+							</IconButton>
+						)}
+						{match.total - match.current > 1 && (
+							<IconButton sx={styles.p0} onClick={onChangeGame(match.total)}>
+								<KeyboardDoubleArrowRightIcon color="primary" />
+							</IconButton>
+						)}
+						<Typography sx={styles.liveBadge} ml="6px">
+							{t('pages.shared.liveBadge')}
+						</Typography>
+					</Stack>
+				</Stack>
+				<IconButton
+					color="primary"
+					onClick={toggleShowResult}
+					aria-label={t('pages.playing.leaderboard')}
+				>
+					<LeaderboardIcon />
+				</IconButton>
+			</Stack>
+			<LeaderBoard />
+			<Box sx={styles.players}>
+				{players.map((player) => (
+					<Player key={player.id} player={player} onRename={() => {}} readOnly />
+				))}
+			</Box>
+		</PlayingLayout>
+	);
+}
+
+export default SharedViewPage;

--- a/src/pages/SharedViewPage/hooks/index.ts
+++ b/src/pages/SharedViewPage/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useSharedView } from './useSharedView';

--- a/src/pages/SharedViewPage/hooks/useSharedView.ts
+++ b/src/pages/SharedViewPage/hooks/useSharedView.ts
@@ -1,0 +1,50 @@
+import { useShareSocket } from '@/hooks';
+import { useAppDispatch } from '@/redux/hooks';
+import { updateIsShowResult, updateMatchDetail } from '@/redux/slices/matchSlice';
+import { matchService } from '@/services';
+import { saveSharedHistory } from '@/utils/helpers';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
+
+function useSharedView() {
+	const { token } = useParams();
+	const dispatch = useAppDispatch();
+	const [isLoading, setIsLoading] = useState(true);
+	const [hasError, setHasError] = useState(false);
+
+	useEffect(() => {
+		if (!token) {
+			setHasError(true);
+			setIsLoading(false);
+			return;
+		}
+
+		let isActive = true;
+
+		matchService
+			.getShared(token)
+			.then((match) => {
+				if (!isActive) return;
+				const total = match.players.find(Boolean)?.scores.length || 1;
+				dispatch(updateMatchDetail({ current: total, total, data: match }));
+				if (match.isFinished) dispatch(updateIsShowResult(true));
+				saveSharedHistory(token, match.name);
+				setIsLoading(false);
+			})
+			.catch(() => {
+				if (!isActive) return;
+				setHasError(true);
+				setIsLoading(false);
+			});
+
+		return () => {
+			isActive = false;
+		};
+	}, [token, dispatch]);
+
+	useShareSocket(token);
+
+	return { isLoading, hasError };
+}
+
+export default useSharedView;

--- a/src/pages/SharedViewPage/index.ts
+++ b/src/pages/SharedViewPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from './SharedViewPage';

--- a/src/pages/SharedViewPage/styles.ts
+++ b/src/pages/SharedViewPage/styles.ts
@@ -1,0 +1,56 @@
+import { SxProps, Theme, alpha } from '@mui/material';
+
+const styles: Record<string, SxProps<Theme>> = {
+	stateWrapper: {
+		display: 'flex',
+		flexDirection: 'column',
+		alignItems: 'center',
+		justifyContent: 'center',
+		gap: '12px',
+		minHeight: '60vh',
+	},
+	header: (theme: Theme) => ({
+		position: 'sticky',
+		top: 0,
+		zIndex: 2,
+		padding: '12px 1rem',
+		backgroundColor: theme.palette.background.paper,
+		borderBottom: `1px solid ${theme.palette.divider}`,
+	}),
+	matchTitle: {
+		fontSize: '16px',
+		fontWeight: 'bold',
+		overflow: 'hidden',
+		textOverflow: 'ellipsis',
+		whiteSpace: 'nowrap',
+	},
+	p0: {
+		padding: 0,
+	},
+	roundPill: (theme: Theme) => ({
+		display: 'inline-flex',
+		alignItems: 'center',
+		padding: '2px 10px',
+		borderRadius: '999px',
+		backgroundColor: alpha(theme.palette.primary.main, 0.12),
+		color: theme.palette.primary.main,
+	}),
+	roundPillText: {
+		fontSize: '13px',
+		fontWeight: 'bold',
+		lineHeight: 1.4,
+	},
+	liveBadge: (theme: Theme) => ({
+		fontSize: '12px',
+		fontWeight: 'bold',
+		color: theme.palette.primary.main,
+	}),
+	players: {
+		display: 'flex',
+		flexDirection: 'column',
+		padding: '12px 1rem',
+		gap: '8px',
+	},
+};
+
+export default styles;

--- a/src/pages/index.ts
+++ b/src/pages/index.ts
@@ -1,3 +1,5 @@
 export { default as HomePage } from './HomePage';
 export { default as CreatingPage } from './CreatingPage';
 export { default as PlayingPage } from './PlayingPage';
+export { default as SharedViewPage } from './SharedViewPage';
+export { default as DashboardPage } from './DashboardPage';

--- a/src/redux/slices/matchSlice.ts
+++ b/src/redux/slices/matchSlice.ts
@@ -1,6 +1,6 @@
 import { Match } from '@/utils/types';
 import { matchService } from '@/services';
-import { createSlice, PayloadAction } from '@reduxjs/toolkit';
+import { createAsyncThunk, createSlice, PayloadAction } from '@reduxjs/toolkit';
 
 interface MatchDetail {
 	isShowResult?: boolean;
@@ -15,9 +15,11 @@ interface MatchState {
 }
 
 const initialState: MatchState = {
-	matches: matchService.getAll(),
+	matches: [],
 	matchDetail: undefined,
 };
+
+export const fetchMatches = createAsyncThunk('match/fetchMatches', () => matchService.getAll());
 
 const matchSlice = createSlice({
 	name: 'match',
@@ -31,6 +33,14 @@ const matchSlice = createSlice({
 			if (!state.matchDetail) return;
 			state.matchDetail.data = action.payload;
 		},
+		updatePlayerScore: (
+			state,
+			action: PayloadAction<{ playerId: number; gameIndex: number; value: number }>,
+		) => {
+			const player = state.matchDetail?.data.players.find((p) => p.id === action.payload.playerId);
+			if (!player) return;
+			player.scores[action.payload.gameIndex] = action.payload.value;
+		},
 		updateIsShowResult: (state, action: PayloadAction<boolean>) => {
 			if (!state.matchDetail) return;
 			state.matchDetail.isShowResult = action.payload;
@@ -38,18 +48,20 @@ const matchSlice = createSlice({
 		updateMatchDetail: (state, action: PayloadAction<MatchDetail>) => {
 			state.matchDetail = action.payload;
 		},
-		updateMatches: (state, action: PayloadAction<Match[]>) => {
+	},
+	extraReducers: (builder) => {
+		builder.addCase(fetchMatches.fulfilled, (state, action) => {
 			state.matches = action.payload;
-		},
+		});
 	},
 });
 
 export const {
 	updateMatchDetail,
-	updateMatches,
 	updateCurrentGame,
 	updateIsShowResult,
 	updateMatchDetailData,
+	updatePlayerScore,
 } = matchSlice.actions;
 
 export default matchSlice.reducer;

--- a/src/routes/constants.ts
+++ b/src/routes/constants.ts
@@ -2,6 +2,8 @@ export const ROUTES = {
 	HOME: '/',
 	CREATE_NEW_MATCH: '/match/create',
 	MATCH: '/match/:id',
+	SHARE: '/share/:token',
+	DASHBOARD: '/dashboard',
 };
 
 export const MIN_PLAYERS_OF_MATCH = 2;

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -1,5 +1,5 @@
 import { Layout } from '@/components';
-import { CreatingPage, HomePage, PlayingPage } from '@/pages';
+import { CreatingPage, DashboardPage, HomePage, PlayingPage, SharedViewPage } from '@/pages';
 import { createBrowserRouter } from 'react-router-dom';
 import { ROUTES } from './constants';
 
@@ -19,6 +19,14 @@ const router = createBrowserRouter([
 			{
 				path: ROUTES.MATCH,
 				element: <PlayingPage />,
+			},
+			{
+				path: ROUTES.SHARE,
+				element: <SharedViewPage />,
+			},
+			{
+				path: ROUTES.DASHBOARD,
+				element: <DashboardPage />,
 			},
 		],
 	},

--- a/src/services/match/index.ts
+++ b/src/services/match/index.ts
@@ -1,121 +1,74 @@
 import matchDB from '@/db/match';
-import { Match, MatchWithoutPlayers, Player } from '@/utils/types';
-import { ERROR_MESSAGES } from '@/utils/constants/errors';
+import { Match, Player } from '@/utils/types';
 import {
-	validateAllGameScores,
-	validateGameNumber,
 	validateMatchId,
 	validateMatchName,
 	validatePlayerId,
 	validatePlayerName,
-	validateSingleGameScore,
 } from '@/utils/validators/matchValidator';
-import { isNil } from '@/utils/helpers';
-import dayjs from 'dayjs';
 
 /**
  * Creates a new match
  * @param name - The name of the match
  * @returns The created match
- * @throws Error if name is empty
  */
-const create = (name: string): Match => {
+const create = (name: string): Promise<Match> => {
 	validateMatchName(name);
-
-	const newMatchBasicInfo: MatchWithoutPlayers = {
-		id: dayjs().valueOf(),
-		name,
-	};
-
-	return matchDB.createMatch(newMatchBasicInfo);
+	return matchDB.createMatch(name);
 };
 
 /**
  * Gets a match by ID
  * @param id - The match ID
  * @returns The match
- * @throws Error if match not found
  */
-const get = (id: number): Match => {
-	const match = matchDB.getMatch(id);
-
-	if (!match) {
-		throw new Error(ERROR_MESSAGES.MATCH_NOT_FOUND);
-	}
-
-	return match;
-};
+const get = (id: number): Promise<Match> => matchDB.getMatch(id);
 
 /**
  * Gets all matches
  * @returns Array of all matches
  */
-const getAll = (): Match[] => {
-	return matchDB.getMatches();
-};
+const getAll = (): Promise<Match[]> => matchDB.getMatches();
 
 /**
  * Deletes a match by ID
  * @param id - The match ID to delete
  */
-const deleteMatch = (id: number): void => {
-	matchDB.deleteMatch(id);
-};
+const deleteMatch = (id: number): Promise<void> => matchDB.deleteMatch(id);
 
 /**
  * Adds a player to a match
  * @param matchId - The match ID
  * @param name - The player name
- * @returns The created player
- * @throws Error if match ID or name is invalid, or if name already exists
+ * @returns The updated match snapshot
  */
-const addPlayer = (matchId: number, name: string): Player => {
+const addPlayer = (matchId: number, name: string): Promise<Match> => {
 	validateMatchId(matchId);
 	validatePlayerName(name);
-
-	const currentGameNumber = getCurrentGameNumber(matchId);
-
-	const newPlayer: Player = {
-		id: dayjs().valueOf(),
-		name,
-		scores: Array(currentGameNumber).fill(0),
-	};
-
-	const player = matchDB.addPlayerToMatch(matchId, newPlayer);
-
-	if (!player) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NAME_EXISTS(name));
-	}
-
-	return player;
+	return matchDB.addPlayerToMatch(matchId, name);
 };
 
 /**
- * Updates a player's name
+ * Updates a player's name, optionally with a new avatar in the same request
  * @param matchId - The match ID
  * @param playerId - The player ID
  * @param newName - The new player name
- * @returns The updated player
- * @throws Error if IDs or name are invalid, or if player not found
+ * @param avatar - Base64 image string, null to remove, undefined to keep unchanged
+ * @returns The updated match snapshot
  */
-const updatePlayerName = (matchId: number, playerId: number, newName: string): Player => {
+const updatePlayerName = (
+	matchId: number,
+	playerId: number,
+	newName: string,
+	avatar?: string | null,
+): Promise<Match> => {
 	validateMatchId(matchId);
 	validatePlayerId(playerId);
 	validatePlayerName(newName);
-
-	const currentPlayer = matchDB.getPlayerOfMatch(matchId, playerId);
-	if (!currentPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
-	}
-
-	currentPlayer.name = newName;
-	const updatedPlayer = matchDB.updatePlayerOfMatch(matchId, currentPlayer);
-
-	if (!updatedPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NAME_DUPLICATE);
-	}
-
-	return updatedPlayer;
+	return matchDB.updatePlayer(matchId, playerId, {
+		name: newName,
+		...(avatar !== undefined && { avatar }),
+	});
 };
 
 /**
@@ -124,207 +77,60 @@ const updatePlayerName = (matchId: number, playerId: number, newName: string): P
  * @param playerId - The player ID
  * @param gameNumber - The game number (1-indexed)
  * @param score - The new score
- * @returns The updated player
- * @throws Error if any parameters are invalid or player not found
+ * @returns The updated match snapshot
  */
 const updateScoreOfPlayer = (
 	matchId: number,
 	playerId: number,
 	gameNumber: number,
 	score: number,
-): Player => {
+): Promise<Match> => {
 	validateMatchId(matchId);
 	validatePlayerId(playerId);
-	validateGameNumber(gameNumber);
-
-	if (isNil(score)) {
-		throw new Error(ERROR_MESSAGES.GAME_SCORE_INVALID);
-	}
-
-	const currentPlayer = matchDB.getPlayerOfMatch(matchId, playerId);
-	if (!currentPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
-	}
-
-	if (gameNumber > currentPlayer.scores.length) {
-		throw new Error(ERROR_MESSAGES.GAME_NUMBER_INVALID);
-	}
-
-	currentPlayer.scores[gameNumber - 1] = score;
-
-	const updatedPlayer = matchDB.updatePlayerOfMatch(matchId, currentPlayer);
-
-	if (!updatedPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
-	}
-
-	recalculateAutoFillPlayer(matchId, gameNumber);
-
-	return updatedPlayer;
+	return matchDB.updateScore(matchId, playerId, gameNumber - 1, score);
 };
 
 /**
  * Updates the position/order of players in a match
  * @param matchId - The match ID
  * @param players - The reordered players array
- * @throws Error if match ID is invalid
+ * @returns The updated match snapshot
  */
-const updatePositionOfPlayer = (matchId: number, players: Player[]): void => {
+const updatePositionOfPlayer = (matchId: number, players: Player[]): Promise<Match> => {
 	validateMatchId(matchId);
-	matchDB.updatePlayersPositionOfMatch(matchId, players);
-};
-
-/**
- * Gets the current game number for a match
- * @param id - The match ID
- * @returns The current game number (1-indexed)
- * @throws Error if match not found
- */
-const getCurrentGameNumber = (id: number): number => {
-	const match = matchDB.getMatch(id);
-
-	if (!match) {
-		throw new Error(ERROR_MESSAGES.MATCH_NOT_FOUND);
-	}
-
-	return match.players.find(Boolean)?.scores.length || 1;
-};
-
-/**
- * Validates that a game's scores sum to zero
- * @param matchId - The match ID
- * @param gameNumber - The game number to validate
- * @returns true if valid
- * @throws Error if match not found or scores don't sum to zero
- */
-const validateGameNumberScores = (matchId: number, gameNumber: number): boolean => {
-	validateMatchId(matchId);
-
-	const match = matchDB.getMatch(matchId);
-	if (!match) {
-		throw new Error(ERROR_MESSAGES.MATCH_NOT_FOUND);
-	}
-
-	validateSingleGameScore(match, gameNumber);
-
-	return true;
+	return matchDB.updatePlayersPosition(matchId, players);
 };
 
 /**
  * Advances to the next game
  * @param id - The match ID
- * @returns The updated match with new game
- * @throws Error if match not found, has insufficient players, or scores invalid
+ * @returns The updated match snapshot
  */
-const nextGame = (id: number): Match => {
+const nextGame = (id: number): Promise<Match> => {
 	validateMatchId(id);
-
-	const match = matchDB.getMatch(id);
-	if (!match) {
-		throw new Error(ERROR_MESSAGES.MATCH_NOT_FOUND);
-	}
-
-	const currentGameNumber = getCurrentGameNumber(id);
-	validateAllGameScores(match, currentGameNumber);
-
-	match.players.forEach((player) => player.scores.push(0));
-	matchDB.updatePlayersOfMatch(id, match.players);
-
-	return match;
+	return matchDB.nextGame(id);
 };
 
 /**
  * Ends the match and marks it as finished
  * @param id - The match ID
- * @returns The finished match
- * @throws Error if match not found, has insufficient players, or scores invalid
+ * @returns The finished match snapshot
  */
-const endGame = (id: number): Match => {
+const endGame = (id: number): Promise<Match> => {
 	validateMatchId(id);
-
-	const match = matchDB.getMatch(id);
-	if (!match) {
-		throw new Error(ERROR_MESSAGES.MATCH_NOT_FOUND);
-	}
-
-	const currentGameNumber = getCurrentGameNumber(id);
-	validateAllGameScores(match, currentGameNumber);
-
-	matchDB.updatePlayersOfMatch(id, match.players);
-	matchDB.updateMatch({
-		id,
-		name: match.name,
-		isFinished: true,
-	});
-	match.isFinished = true;
-
-	return match;
-};
-
-/**
- * Recalculates the autoFill player's score for a given game
- * @param matchId - The match ID
- * @param gameNumber - The game number (1-indexed)
- */
-const recalculateAutoFillPlayer = (matchId: number, gameNumber: number): void => {
-	const match = matchDB.getMatch(matchId);
-	if (!match) return;
-
-	const autoFillPlayer = match.players.find((p) => p.autoFill);
-	if (!autoFillPlayer) return;
-
-	const otherPlayersSum = match.players
-		.filter((p) => p.id !== autoFillPlayer.id)
-		.reduce((sum, p) => sum + (p.scores[gameNumber - 1] || 0), 0);
-
-	autoFillPlayer.scores[gameNumber - 1] = -otherPlayersSum;
-	matchDB.updatePlayerOfMatch(matchId, autoFillPlayer);
+	return matchDB.endGame(id);
 };
 
 /**
  * Toggles autoFill for a player. Only one player can have autoFill at a time.
  * @param matchId - The match ID
  * @param playerId - The player ID
- * @param gameNumber - The current game number (1-indexed)
- * @returns The updated match
+ * @returns The updated match snapshot
  */
-const togglePlayerAutoFill = (matchId: number, playerId: number, gameNumber: number): Match => {
+const togglePlayerAutoFill = (matchId: number, playerId: number): Promise<Match> => {
 	validateMatchId(matchId);
 	validatePlayerId(playerId);
-
-	const match = matchDB.getMatch(matchId);
-	if (!match) {
-		throw new Error(ERROR_MESSAGES.MATCH_NOT_FOUND);
-	}
-
-	const targetPlayer = match.players.find((p) => p.id === playerId);
-	if (!targetPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
-	}
-
-	const isEnabling = !targetPlayer.autoFill;
-
-	// Clear autoFill from all players first
-	match.players.forEach((p) => {
-		if (p.autoFill) {
-			p.autoFill = undefined;
-			matchDB.updatePlayerOfMatch(matchId, p);
-		}
-	});
-
-	if (isEnabling) {
-		targetPlayer.autoFill = true;
-
-		// Calculate score immediately
-		const otherPlayersSum = match.players
-			.filter((p) => p.id !== playerId)
-			.reduce((sum, p) => sum + (p.scores[gameNumber - 1] || 0), 0);
-		targetPlayer.scores[gameNumber - 1] = -otherPlayersSum;
-
-		matchDB.updatePlayerOfMatch(matchId, targetPlayer);
-	}
-
-	return get(matchId);
+	return matchDB.toggleAutoFill(matchId, playerId);
 };
 
 /**
@@ -332,53 +138,30 @@ const togglePlayerAutoFill = (matchId: number, playerId: number, gameNumber: num
  * @param matchId - The match ID
  * @param playerId - The player ID
  * @param gap - The new gap value (undefined to use global setting)
- * @returns The updated player
- * @throws Error if IDs are invalid or player not found
+ * @returns The updated match snapshot
  */
-const updatePlayerGap = (matchId: number, playerId: number, gap?: number): Player => {
+const updatePlayerGap = (matchId: number, playerId: number, gap?: number): Promise<Match> => {
 	validateMatchId(matchId);
 	validatePlayerId(playerId);
-
-	const currentPlayer = matchDB.getPlayerOfMatch(matchId, playerId);
-	if (!currentPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
-	}
-
-	currentPlayer.gap = gap;
-	const updatedPlayer = matchDB.updatePlayerOfMatch(matchId, currentPlayer);
-
-	if (!updatedPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
-	}
-
-	return updatedPlayer;
+	return matchDB.updatePlayer(matchId, playerId, { gap });
 };
 
 /**
- * Updates a player's avatar
- * @param matchId - The match ID
- * @param playerId - The player ID
- * @param avatar - Base64 image string (undefined to remove)
- * @returns The updated player
+ * Creates (or reuses) a public share link for a match
+ * @param id - The match ID
+ * @returns The share token
  */
-const updatePlayerAvatar = (matchId: number, playerId: number, avatar?: string): Player => {
-	validateMatchId(matchId);
-	validatePlayerId(playerId);
-
-	const currentPlayer = matchDB.getPlayerOfMatch(matchId, playerId);
-	if (!currentPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
-	}
-
-	currentPlayer.avatar = avatar;
-	const updatedPlayer = matchDB.updatePlayerOfMatch(matchId, currentPlayer);
-
-	if (!updatedPlayer) {
-		throw new Error(ERROR_MESSAGES.PLAYER_NOT_FOUND);
-	}
-
-	return updatedPlayer;
+const share = (id: number): Promise<{ token: string }> => {
+	validateMatchId(id);
+	return matchDB.shareMatch(id);
 };
+
+/**
+ * Gets a shared match by its public token (no device ownership required)
+ * @param token - The share token
+ * @returns The match snapshot
+ */
+const getShared = (token: string): Promise<Match> => matchDB.getSharedMatch(token);
 
 const matchService = {
 	create,
@@ -390,12 +173,11 @@ const matchService = {
 	updateScoreOfPlayer,
 	updatePositionOfPlayer,
 	updatePlayerGap,
-	updatePlayerAvatar,
 	togglePlayerAutoFill,
-	getCurrentGameNumber,
-	validateGameNumber: validateGameNumberScores,
 	nextGame,
 	endGame,
+	share,
+	getShared,
 };
 
 export default matchService;

--- a/src/utils/helpers/deviceId.ts
+++ b/src/utils/helpers/deviceId.ts
@@ -1,0 +1,15 @@
+const DEVICE_ID_KEY = 'deviceId';
+
+/**
+ * Returns the anonymous device UUID, generating and persisting it once.
+ */
+export const getDeviceId = (): string => {
+	let deviceId = localStorage.getItem(DEVICE_ID_KEY);
+
+	if (!deviceId) {
+		deviceId = crypto.randomUUID();
+		localStorage.setItem(DEVICE_ID_KEY, deviceId);
+	}
+
+	return deviceId;
+};

--- a/src/utils/helpers/errorTranslator.ts
+++ b/src/utils/helpers/errorTranslator.ts
@@ -19,7 +19,7 @@ export const translateError = (error: unknown, t: TFunction): string => {
 		try {
 			const parsed = JSON.parse(message);
 			if (parsed.key && parsed.params) {
-				return t(parsed.key, parsed.params);
+				return t(parsed.key, parsed.params) as string;
 			}
 		} catch {
 			// Not JSON, return as is

--- a/src/utils/helpers/index.ts
+++ b/src/utils/helpers/index.ts
@@ -130,6 +130,13 @@ export const scrollToTop = (): void => {
 // Export error translator
 export { translateError } from './errorTranslator';
 
+// Export device id helper
+export { getDeviceId } from './deviceId';
+
+// Export shared-view history helpers
+export { getSharedHistory, saveSharedHistory, removeSharedHistory } from './shareHistory';
+export type { SharedHistoryEntry } from './shareHistory';
+
 // Default export for backward compatibility
 const helpers = {
 	formatCurrency,

--- a/src/utils/helpers/shareHistory.ts
+++ b/src/utils/helpers/shareHistory.ts
@@ -1,0 +1,28 @@
+const STORAGE_KEY = 'sharedHistory';
+const MAX_ENTRIES = 20;
+
+export interface SharedHistoryEntry {
+	token: string;
+	name: string;
+	viewedAt: string;
+}
+
+export const getSharedHistory = (): SharedHistoryEntry[] => {
+	try {
+		return JSON.parse(localStorage.getItem(STORAGE_KEY) ?? '[]');
+	} catch {
+		return [];
+	}
+};
+
+export const saveSharedHistory = (token: string, name: string): void => {
+	const entries = getSharedHistory().filter((entry) => entry.token !== token);
+	entries.unshift({ token, name, viewedAt: new Date().toISOString() });
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(entries.slice(0, MAX_ENTRIES)));
+};
+
+export const removeSharedHistory = (token: string): SharedHistoryEntry[] => {
+	const entries = getSharedHistory().filter((entry) => entry.token !== token);
+	localStorage.setItem(STORAGE_KEY, JSON.stringify(entries));
+	return entries;
+};

--- a/src/utils/types/index.ts
+++ b/src/utils/types/index.ts
@@ -10,6 +10,7 @@ export interface Player {
 export interface MatchWithoutPlayers {
 	id: number;
 	name: string;
+	createdAt?: string;
 	isFinished?: boolean;
 }
 


### PR DESCRIPTION
…min dashboard

- Replace localStorage data layer with REST client (native fetch, X-Device-Id ownership)
- Async service/hook/redux chain with optimistic score updates and per-cell debounce
- Live share: permanent read-only /share/:token view over WebSocket with game navigation
- Shared-view history section in match listing dialog
- Admin dashboard at /dashboard (login, match list, read-only detail)
- Fix 1970 dates by using server createdAt