### PR TITLE
feat(share): flash highlight on live score updates

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -3,3 +3,4 @@ export { default as useBoolean } from './useBoolean';
 export { default as useAddQueryParams } from './useAddQueryParams';
 export { default as useFormatCurrency } from './useFormatCurrency';
 export { default as useShareSocket } from './useShareSocket';
+export { default as useFlashOnChange } from './useFlashOnChange';

--- a/src/hooks/useFlashOnChange.ts
+++ b/src/hooks/useFlashOnChange.ts
@@ -1,0 +1,28 @@
+import { useEffect, useRef, useState } from 'react';
+
+const FLASH_MS = 1200;
+
+/**
+ * Returns true for a short moment after `value` changes, so the UI can flash
+ * a highlight. Changing `contextKey` (e.g. the viewed game number) resets the
+ * baseline without flashing — only real data changes trigger the highlight.
+ */
+function useFlashOnChange(value: number, contextKey: number): boolean {
+	const [isFlashing, setIsFlashing] = useState(false);
+	const prevRef = useRef({ value, contextKey });
+
+	useEffect(() => {
+		const prev = prevRef.current;
+		prevRef.current = { value, contextKey };
+
+		if (prev.contextKey !== contextKey || prev.value === value) return;
+
+		setIsFlashing(true);
+		const timer = setTimeout(() => setIsFlashing(false), FLASH_MS);
+		return () => clearTimeout(timer);
+	}, [value, contextKey]);
+
+	return isFlashing;
+}
+
+export default useFlashOnChange;

--- a/src/pages/PlayingPage/components/Player/Player.tsx
+++ b/src/pages/PlayingPage/components/Player/Player.tsx
@@ -1,4 +1,5 @@
 import { InputScore } from '@/components';
+import { useFlashOnChange } from '@/hooks';
 import { useAppSelector } from '@/redux/hooks';
 import { RootState } from '@/redux/store';
 import helpers from '@/utils/helpers';
@@ -47,6 +48,10 @@ function Player({ player, onRename, dragHandleProps, isDragEnabled, readOnly }: 
 	const currentValue = player.scores[currentGameNumber - 1] || 0;
 	const effectiveGap = player.gap ?? setting.gap;
 	const hasCustomGap = player.gap !== undefined;
+	// Live share view: flash values freshly changed by an incoming snapshot.
+	// currentGameNumber as context key so browsing rounds does not flash.
+	const flashTotal = useFlashOnChange(total, currentGameNumber) && readOnly;
+	const flashCurrent = useFlashOnChange(currentValue, currentGameNumber) && readOnly;
 	const showDragHandle = !readOnly && isDragEnabled && setting.uiMode === 'full';
 	const nameIsDragHandle = !readOnly && !!isDragEnabled && setting.uiMode === 'compact';
 
@@ -103,7 +108,11 @@ function Player({ player, onRename, dragHandleProps, isDragEnabled, readOnly }: 
 					<Stack sx={styles.scoreCell} alignItems="flex-start">
 						<Typography sx={styles.scoreCaption}>{t('pages.playing.total')}</Typography>
 						<Stack direction="row" alignItems="baseline" gap="6px">
-							<Typography sx={styles.totalValue(total)}>{total}</Typography>
+							<Typography
+								sx={[styles.totalValue(total), ...(flashTotal ? [styles.scoreFlash] : [])]}
+							>
+								{total}
+							</Typography>
 							{showTrend && (
 								<Stack sx={styles.trendWrapper(increasingTrendValue)}>
 									{increasingTrendValue > 0 && <TrendingUpIcon sx={styles.trendIndicator} />}
@@ -116,7 +125,11 @@ function Player({ player, onRename, dragHandleProps, isDragEnabled, readOnly }: 
 					</Stack>
 					<Stack sx={styles.scoreCell} alignItems="flex-end">
 						{readOnly ? (
-							<Typography sx={styles.totalValue(currentValue)}>{currentValue}</Typography>
+							<Typography
+								sx={[styles.totalValue(currentValue), ...(flashCurrent ? [styles.scoreFlash] : [])]}
+							>
+								{currentValue}
+							</Typography>
 						) : (
 							<InputScore
 								disabled={isFinished || !!player.autoFill}

--- a/src/pages/PlayingPage/components/Player/styles.ts
+++ b/src/pages/PlayingPage/components/Player/styles.ts
@@ -52,6 +52,17 @@ const styles = {
 		letterSpacing: '0.04em',
 		color: theme.palette.text.secondary,
 	}),
+	scoreFlash: (theme: Theme) => ({
+		borderRadius: '4px',
+		padding: '0 4px',
+		margin: '0 -4px',
+		animation: 'score-flash 1.2s ease-out',
+		'@keyframes score-flash': {
+			'0%': { backgroundColor: alpha(theme.palette.primary.main, 0.45) },
+			'50%': { backgroundColor: alpha(theme.palette.primary.main, 0.25) },
+			'100%': { backgroundColor: 'transparent' },
+		},
+	}),
 	totalValue: (total: number) => (theme: Theme) => ({
 		fontWeight: 'bold',
 		fontSize: '22px',


### PR DESCRIPTION
- useFlashOnChange hook: flashes only on real data changes, browsing rounds does not trigger it
- Applied to round score and total in the read-only viewer