### PR TITLE
fix(seo): keep the document title in sync with the page title

### DIFF
--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -1,6 +1,6 @@
 {
 	"app": {
-		"title": "Score Tracker Application",
+		"title": "Ghi Điểm Online — Track scores for every game with friends",
 		"description": "Help you track game scores quickly and easily"
 	},
 	"common": {

--- a/src/i18n/locales/vi.json
+++ b/src/i18n/locales/vi.json
@@ -1,6 +1,6 @@
 {
 	"app": {
-		"title": "Ghi Điểm Application",
+		"title": "Ghi Điểm Online — Ghi điểm mọi trò chơi cùng bạn bè",
 		"description": "Hỗ trợ bạn ghi điểm của cuộc chơi nhanh gọn lẹ"
 	},
 	"common": {


### PR DESCRIPTION
App.tsx overwrites document.title from app.title once React mounts, so the tab and any JS-executing crawler saw "Ghi Điểm Application" instead of the title declared in index.html.